### PR TITLE
Fix: Flow freshness check always reads stale due to key-name mismatch with Node stamper

### DIFF
--- a/docs/living-doc-compositor.html
+++ b/docs/living-doc-compositor.html
@@ -2697,10 +2697,13 @@
     return String(value || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '').slice(0, 64);
   }
   function govSectionSignature() {
+    // Key names must match scripts/meta-fingerprint.mjs exactly — the Node
+    // stamper and this browser check produce different sha256 hashes otherwise,
+    // and every crystallized doc reads as stale in the Flow view. See #58.
     return JSON.stringify((state.sections || []).map((s) => ({
       id: String(s?.id || ''),
-      t: String(s?.convergenceType || ''),
-      c: (Array.isArray(s?.data) ? s.data : []).map((item) => String(item?.id || '')).filter(Boolean),
+      type: String(s?.convergenceType || ''),
+      cards: (Array.isArray(s?.data) ? s.data : []).map((item) => String(item?.id || '')).filter(Boolean),
     })));
   }
   async function govComputeFingerprint() {


### PR DESCRIPTION
## Summary

The browser's \`govSectionSignature\` (inside the compositor's Flow view) serialized each section as \`{ id, t, c }\`, while the Node stamper \`computeSectionFingerprint\` in \`scripts/meta-fingerprint.mjs\` serializes as \`{ id, type, cards }\`. Same input sections, different JSON, different sha256 — so the browser's live-computed fingerprint could never match the stamped one, and every crystallized doc read as stale in the Flow view.

## Root cause

Divergent implementations. I introduced \`govSectionSignature\` in #44 when adding the tabular governance panel and used terse keys because it was serving a minimal in-browser use case at the time. Later work (#50 stale banner, #58 bug report) depended on it matching the Node stamper exactly and didn't notice the mismatch.

## Fix

Align the browser's serialization with the Node stamper. One-character-for-one-character match, same filter order, same String coercion.

## Verification

Against the crystallized \`docs/proof-ladder-overview.json\` in the parser MVP repo:

\`\`\`
stored fingerprint: sha256:d31e2bed...
computed (fixed):   sha256:d31e2bed...
match: true
\`\`\`

Before this fix, the browser would compute a different hash and the Flow tab would always show the stale banner on a freshly-stamped doc.

## Scope

Fixes the primary repro in #58. The wider issues in #58 (per-doc localStorage keying, postMessage ordering in embedded mode) remain open — this patch just removes the universal false-positive that hit every crystallized doc.

## Downstream propagation

Every downstream rendered HTML (proof-ladder-overview.html, compositor-development-overview.html, mobile-companion-workstream.html, mobile-subscription-refinement-model.html, blog-governance-layer.html, living-doc-example-coherence.html, etc.) embeds the compositor inline. Any doc rendered before this fix still carries the buggy serialization and needs a rerender.

🤖 Generated with [Claude Code](https://claude.com/claude-code)