### PR TITLE
Re-render governance-backed docs after fingerprint fix

### DIFF
--- a/docs/compositor-development-overview.html
+++ b/docs/compositor-development-overview.html
@@ -4140,10 +4140,13 @@
     return String(value || &#39;&#39;).toLowerCase().replace(/[^a-z0-9]+/g, &#39;-&#39;).replace(/^-|-$/g, &#39;&#39;).slice(0, 64);
   }
   function govSectionSignature() {
+    // Key names must match scripts/meta-fingerprint.mjs exactly — the Node
+    // stamper and this browser check produce different sha256 hashes otherwise,
+    // and every crystallized doc reads as stale in the Flow view. See #58.
     return JSON.stringify((state.sections || []).map((s) =&gt; ({
       id: String(s?.id || &#39;&#39;),
-      t: String(s?.convergenceType || &#39;&#39;),
-      c: (Array.isArray(s?.data) ? s.data : []).map((item) =&gt; String(item?.id || &#39;&#39;)).filter(Boolean),
+      type: String(s?.convergenceType || &#39;&#39;),
+      cards: (Array.isArray(s?.data) ? s.data : []).map((item) =&gt; String(item?.id || &#39;&#39;)).filter(Boolean),
     })));
   }
   async function govComputeFingerprint() {
@@ -13988,7 +13991,7 @@ open docs/living-doc-compositor.html&lt;/pre&gt;
 
     <div class="snapshot-item">
       <span class="snapshot-label">Generated</span>
-      <span class="snapshot-value"><time datetime="2026-04-17T12:17:30.112Z" title="2026-04-17T12:17:30.112Z" data-snapshot-anchor="generated-at" id="snapshot-generated-at">2026-04-17T12:17:30.112Z</time></span>
+      <span class="snapshot-value"><time datetime="2026-04-17T13:00:54.216Z" title="2026-04-17T13:00:54.216Z" data-snapshot-anchor="generated-at" id="snapshot-generated-at">2026-04-17T13:00:54.216Z</time></span>
     </div>
 
     <div class="snapshot-item">
@@ -14604,7 +14607,7 @@ open docs/living-doc-compositor.html&lt;/pre&gt;
     </section>
 
 
-          <p class="footnote" style="margin-top:40px">Living Doc Compositor v0.1.0-31ff283 (2026-04-17)</p>
+          <p class="footnote" style="margin-top:40px">Living Doc Compositor v0.1.0-0103671 (2026-04-17)</p>
         </div>
 
     <section id="board-view" class="view-panel board-view" data-view-panel="board" hidden>

--- a/docs/living-doc-example-coherence.html
+++ b/docs/living-doc-example-coherence.html
@@ -794,7 +794,208 @@
     background: var(--card); font-size: 12.5px; font-weight: 600; color: var(--muted);
   }
   .preview-tab.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+  .flow-placeholder {
+    margin: 24px; padding: 32px 36px; border-radius: 14px;
+    background: var(--card); border: 1px dashed var(--line);
+    max-width: 720px;
+  }
+  .flow-placeholder-eyebrow {
+    display: inline-block; padding: 3px 10px; border-radius: 999px;
+    background: color-mix(in srgb, var(--accent) 12%, var(--card));
+    color: var(--accent); font-size: 11px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 12px;
+  }
+  .flow-placeholder h3 { margin: 0 0 8px; font-size: 18px; letter-spacing: -0.01em; }
+  .flow-placeholder p { margin: 0 0 16px; color: var(--muted); line-height: 1.6; font-size: 13.5px; }
+  .flow-placeholder-summary {
+    padding: 10px 14px; border-radius: 8px;
+    background: color-mix(in srgb, var(--accent) 6%, var(--card));
+    border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--line));
+    font-size: 12.5px; color: var(--ink);
+  }
+  .flow-placeholder-summary-empty {
+    background: color-mix(in srgb, #f59e0b 10%, var(--card));
+    border-color: color-mix(in srgb, #f59e0b 30%, var(--line));
+    color: #92400e;
+  }
+  .flow-view { display: flex; flex-direction: column; min-height: 100%; }
+  .flow-stats {
+    display: flex; gap: 6px; padding: 10px 16px;
+    border-bottom: 1px solid var(--line); background: var(--card);
+    flex-wrap: wrap; position: sticky; top: 0; z-index: 2;
+  }
+  .flow-stat {
+    display: inline-flex; gap: 6px; padding: 4px 10px; border-radius: 999px;
+    background: var(--bg); border: 1px solid var(--line); font-size: 12px;
+  }
+  .flow-stat strong { color: var(--ink); font-weight: 700; }
+  .flow-stat-warn { background: #fffbeb; color: #92400e; border-color: #fde68a; }
+  .flow-stat-bad { background: #fef2f2; color: #991b1b; border-color: #fecaca; }
+  .flow-canvas-wrap {
+    position: relative; flex: 1; overflow: auto; background: var(--bg);
+    min-height: 420px;
+  }
+  .flow-canvas {
+    position: relative; display: grid;
+    grid-template-columns: 260px 260px 260px;
+    gap: 72px; padding: 24px 28px 48px;
+    min-width: 924px;
+    justify-content: start;
+  }
+  .flow-col h4 {
+    margin: 0 0 10px; font-size: 11px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted);
+  }
+  .flow-col h4 .flow-col-count {
+    margin-left: 6px; padding: 1px 8px; border-radius: 999px;
+    background: var(--card); border: 1px solid var(--line);
+    color: var(--muted); font-size: 10px; font-weight: 700;
+  }
+  .flow-nodes { display: flex; flex-direction: column; gap: 10px; }
+  .flow-node {
+    position: relative; padding: 10px 12px 10px 14px;
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  }
+  .flow-node-header {
+    display: flex; gap: 6px; align-items: baseline; flex-wrap: wrap;
+  }
+  .flow-node-header h5 { margin: 0; font-size: 13px; font-weight: 700; }
+  .flow-node-id {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 10.5px; color: var(--muted);
+  }
+  .flow-node-body { margin-top: 4px; font-size: 12px; color: var(--muted); line-height: 1.5; }
+  .flow-badge {
+    display: inline-flex; padding: 1px 8px; border-radius: 999px;
+    font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flow-badge-ct { background: #ecfeff; color: #155e75; margin-left: auto; }
+  .flow-badge-orphan { background: #fef2f2; color: #991b1b; }
+  .flow-badge-docwide { background: #fef3c7; color: #92400e; margin-left: auto; cursor: pointer; border: 1px solid #fde68a; transition: background 0.15s, border-color 0.15s; }
+  .flow-badge-docwide:hover { background: #fde68a; border-color: #f59e0b; }
+  .flow-badge-docwide.flow-badge-docwide-active { background: #d97706; color: #fff; border-color: #d97706; }
+  .flow-badge-docwide.flow-badge-docwide-active:hover { background: #b45309; border-color: #b45309; }
+  .flow-node-orphan {
+    background: color-mix(in srgb, #fef2f2 40%, var(--card));
+    border-color: #fecaca;
+  }
+  .flow-card-chips { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 6px; }
+  .flow-card-chip {
+    display: inline-flex; padding: 1px 7px; border-radius: 5px;
+    background: var(--bg); border: 1px solid var(--line);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 10px; color: var(--muted);
+  }
+  .flow-rationale {
+    margin-top: 8px; padding: 6px 9px; border-radius: 7px;
+    background: var(--bg); border: 1px dashed var(--line);
+    font-size: 11.5px; font-style: italic; color: var(--muted); line-height: 1.5;
+  }
+  .flow-rationale-empty {
+    color: color-mix(in srgb, var(--muted) 55%, var(--card));
+    border-style: dotted;
+  }
+  .flow-invariant {
+    background: color-mix(in srgb, #fffbeb 45%, var(--card));
+    border-color: #fde68a;
+  }
+  .flow-invariant-statement {
+    margin-top: 5px; font-size: 11.5px; color: #78350f; line-height: 1.5;
+  }
+  .flow-port {
+    position: absolute; top: 50%; transform: translateY(-50%);
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--card); border: 2px solid #94a3b8; z-index: 3;
+  }
+  .flow-port-out { right: -7px; }
+  .flow-port-in-left { left: -7px; }
+  .flow-port-in-right { right: -7px; border-color: #d97706; }
+  .flow-port-inv-out { left: -7px; border-color: #d97706; }
+  .flow-wires {
+    position: absolute; inset: 0; width: 100%; height: 100%;
+    pointer-events: none; z-index: 1;
+  }
+  .flow-wires path { fill: none; }
+  .flow-wires path.flow-wire-coverage, .flow-wires path.flow-wire-invariant { pointer-events: none; }
+  .flow-wire-coverage { stroke: #94a3b8; stroke-width: 2; }
+  .flow-wire-coverage.flow-wire-drift { stroke: #b91c1c; stroke-dasharray: 4 4; }
+  .flow-wire-invariant { stroke: #d97706; stroke-width: 2; }
+  .flow-wire-hit { stroke: transparent; stroke-width: 16; pointer-events: stroke; cursor: pointer; }
+  .flow-wire-preview { stroke-dasharray: 6 4; opacity: 0.8; pointer-events: none; }
+  .flow-port { cursor: crosshair; transition: transform 0.12s, background 0.15s, border-color 0.15s; }
+  .flow-port:hover { transform: translateY(-50%) scale(1.35); background: var(--accent); border-color: var(--accent); }
+  .flow-port-in-right:hover, .flow-port-inv-out:hover { background: #d97706; border-color: #d97706; }
+  .flow-port.flow-port-dragging { background: var(--accent); border-color: var(--accent); }
+  .flow-port.flow-port-dragging-inv { background: #d97706; border-color: #d97706; }
+  .flow-remove {
+    position: absolute; top: 6px; right: 6px;
+    width: 20px; height: 20px; border-radius: 50%;
+    border: 1px solid var(--line); background: var(--card);
+    color: var(--muted); font-size: 13px; line-height: 1;
+    cursor: pointer; opacity: 0; transition: opacity 0.15s;
+    display: inline-flex; align-items: center; justify-content: center;
+    padding: 0;
+  }
+  .flow-node:hover .flow-remove { opacity: 1; }
+  .flow-remove:hover { background: #fef2f2; color: #991b1b; border-color: #991b1b; }
+  .flow-rationale { cursor: pointer; transition: border-color 0.15s, color 0.15s; }
+  .flow-rationale:hover { border-color: var(--accent); color: var(--ink); }
+  .flow-banner {
+    display: none; gap: 14px; align-items: center; flex-wrap: wrap;
+    padding: 12px 16px; border-bottom: 1px solid var(--line);
+    background: var(--card); font-size: 13px; line-height: 1.5;
+  }
+  .flow-banner[data-state=&quot;missing&quot;] {
+    display: flex; background: var(--neutral-bg); color: var(--neutral-ink);
+    border-bottom-color: var(--line);
+  }
+  .flow-banner[data-state=&quot;stale&quot;] {
+    display: flex;
+    background: color-mix(in srgb, #fffbeb 65%, var(--card));
+    color: #92400e;
+    border-bottom-color: #fde68a;
+  }
+  .flow-banner strong { font-weight: 700; }
+  .flow-banner-body { flex: 1; min-width: 200px; }
+  .flow-banner-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+  .flow-banner-btn {
+    padding: 5px 12px; font: inherit; font-size: 12px; font-weight: 600;
+    border: 1px solid var(--line); background: var(--card); border-radius: 7px;
+    color: var(--ink); cursor: pointer;
+  }
+  .flow-banner-btn:hover { border-color: var(--accent); color: var(--accent); }
+  .flow-banner-btn-primary { background: #d97706; color: #fff; border-color: #d97706; }
+  .flow-banner-btn-primary:hover { background: #b45309; border-color: #b45309; color: #fff; }
+  .flow-canvas-wrap.flow-stale .flow-wire-coverage,
+  .flow-canvas-wrap.flow-stale .flow-wire-invariant {
+    opacity: 0.4; filter: saturate(0.6);
+  }
+  .flow-canvas-wrap.flow-stale .flow-wire-coverage.flow-wire-drift { opacity: 0.5; }
+  .flow-node { cursor: grab; }
+  .flow-node:active { cursor: grabbing; }
+  .flow-node .flow-port,
+  .flow-node .flow-remove,
+  .flow-node .flow-badge-docwide,
+  .flow-node .flow-rationale { cursor: pointer; }
+  .flow-node[data-flow-positioned=&quot;true&quot;] { position: absolute; z-index: 2; width: 260px; }
+  .flow-node.flow-node-dragging { opacity: 0.85; box-shadow: 0 4px 14px rgba(0,0,0,0.12); cursor: grabbing; z-index: 3; user-select: none; }
+  .flow-node.flow-node-dragging * { user-select: none; }
+  .flow-node .flow-node-header h5 { user-select: none; }
+  .flow-reset-layout-btn {
+    margin-left: auto; padding: 4px 10px; font: inherit; font-size: 12px; font-weight: 600;
+    border: 1px solid var(--line); background: var(--card); border-radius: 7px;
+    color: var(--muted); cursor: pointer;
+  }
+  .flow-reset-layout-btn:hover { border-color: var(--accent); color: var(--accent); }
+  .flow-empty {
+    margin: 24px; padding: 32px 36px; border-radius: 14px;
+    background: var(--card); border: 1px dashed var(--line);
+    max-width: 720px; color: var(--muted); font-size: 13.5px; line-height: 1.6;
+  }
+  .flow-empty strong { color: var(--ink); display: block; margin-bottom: 8px; font-size: 15px; }
   .preview-content { padding: 24px; scroll-behavior: smooth; }
+  .preview-content.preview-content-flow { padding: 0; display: flex; flex-direction: column; }
   .preview-iframe { width: 100%; border: none; border-radius: var(--radius); background: #fff; min-height: calc(100vh - 80px); }
   .doc-editor-card {
     margin-bottom: 18px; padding: 20px; border-radius: 14px;
@@ -1651,7 +1852,26 @@
       &quot;preview&quot;: &quot;Preview&quot;,
       &quot;visual&quot;: &quot;Visual&quot;,
       &quot;board&quot;: &quot;Board&quot;,
+      &quot;flow&quot;: &quot;Flow&quot;,
       &quot;json&quot;: &quot;JSON&quot;,
+      &quot;flowEmptyTitle&quot;: &quot;Governance canvas&quot;,
+      &quot;flowEmptyBody&quot;: &quot;The Flow view renders the doc&#39;s governance layer — objective facets, coverage edges, invariants, and rationale — as a canvas. Canvas rendering lands in #47. Tab is in place; data-flow wiring follows.&quot;,
+      &quot;flowMissingGovernance&quot;: &quot;This doc has no governance data yet. Run /crystallize on the JSON to populate objectiveFacets, coverage, and invariants.&quot;,
+      &quot;flowColFacets&quot;: &quot;Objective facets&quot;,
+      &quot;flowColSections&quot;: &quot;Sections&quot;,
+      &quot;flowColInvariants&quot;: &quot;Invariants&quot;,
+      &quot;flowMetaChecking&quot;: &quot;Checking meta freshness…&quot;,
+      &quot;flowMetaCheckingBody&quot;: &quot;Computing the current section fingerprint.&quot;,
+      &quot;flowMetaMissingTitle&quot;: &quot;Meta not yet stamped.&quot;,
+      &quot;flowMetaMissingBody&quot;: &quot;Run /crystallize to seed objectiveFacets, coverage, invariants, and a metaFingerprint so drift becomes detectable.&quot;,
+      &quot;flowMetaStaleTitle&quot;: &quot;Meta is stale.&quot;,
+      &quot;flowMetaStaleBody&quot;: &quot;Sections have changed since the meta was derived. Coverage edges may point at the wrong cards. Run /crystallize --refresh or stamp a new fingerprint.&quot;,
+      &quot;flowStampNow&quot;: &quot;Stamp fingerprint now&quot;,
+      &quot;flowStamping&quot;: &quot;Stamping…&quot;,
+      &quot;flowStamped&quot;: &quot;Stamped&quot;,
+      &quot;flowCrystallize&quot;: &quot;Copy /crystallize prompt&quot;,
+      &quot;flowCrystallizeCopied&quot;: &quot;Copied&quot;,
+      &quot;flowResetLayout&quot;: &quot;Reset layout&quot;,
       &quot;templates&quot;: &quot;Templates&quot;,
       &quot;templatesHint&quot;: &quot;Browse starter and advanced living doc templates&quot;,
       &quot;templatesIntro&quot;: &quot;Start with a simple starter template or jump straight into a fuller advanced shape.&quot;,
@@ -1787,7 +2007,37 @@
       &quot;guideLayer4FingerprintTitle&quot;: &quot;Fingerprint and freshness&quot;,
       &quot;guideLayer4FingerprintBody&quot;: &quot;A sha256 of the section structure at crystallization time. Renders as a banner when the sections have moved but the meta has not — stale coverage is worse than no coverage, so drift becomes loud.&quot;,
       &quot;guideLayer4CrystallizeTitle&quot;: &quot;Second-pass refinement, not an authoring gate&quot;,
-      &quot;guideLayer4CrystallizeBody&quot;: &quot;Don&#39;t crystallize early iteration — facets haven&#39;t settled. Run `/crystallize &lt;doc&gt;` once the shape is stable; the skill proposes facets, coverage, invariants, and rationale from what the doc already contains. Re-run with `--refresh` on structural change.&quot;,
+      &quot;guideLayer4CrystallizeBody&quot;: &quot;Don&#39;t crystallize early iteration — facets haven&#39;t settled. Run `/crystallize &lt;doc&gt;` once the shape is stable; the skill proposes facets, coverage, invariants, and rationale from what the doc already contains. Re-run with `--refresh` on structural change. Open the Flow tab to watch the facets and coverage populate as the skill writes them.&quot;,
+      &quot;guideLayer4FlowIntro&quot;: &quot;The Flow tab in the compositor is the primary surface for governance. Open a crystallized doc, switch to Flow, and the layer becomes a canvas: facets on the left, sections in the middle, invariants on the right, with typed wires between them.&quot;,
+      &quot;guideLayer4FlowFacets&quot;: &quot;In the Flow canvas: the left column. Orphan facets render as pink cards with an Orphan badge, so gaps in the coverage are visible at a glance. Drag a facet&#39;s right port to a section&#39;s left port to add a coverage edge.&quot;,
+      &quot;guideLayer4FlowCoverage&quot;: &quot;In the Flow canvas: gray bezier wires from each facet&#39;s right port to the section&#39;s left port. Drift (the target section has been removed) renders as a dashed red wire trailing off toward the sections column. Click a wire to remove it.&quot;,
+      &quot;guideLayer4FlowInvariants&quot;: &quot;In the Flow canvas: the right column, amber arrows with arrowheads point at the sections they govern. Click the Doc-wide chip on an invariant to toggle `appliesTo: [\&quot;*\&quot;]`; the arrows collapse into one arrow pointing at a virtual anchor above the sections column. Drag to a specific section to rescope.&quot;,
+      &quot;guideLayer4FlowFingerprint&quot;: &quot;In the Flow canvas: an amber banner pins at the top when the fingerprint is stale. Coverage and invariant wires dim and desaturate so the stale state is unmistakable. The banner&#39;s Stamp button re-computes and stores the new fingerprint; the Crystallize button copies `/crystallize &lt;doc&gt; --refresh` to the clipboard.&quot;,
+      &quot;guideLayer4ReadingTitle&quot;: &quot;Reading the Flow canvas&quot;,
+      &quot;guideLayer4ReadingBody&quot;: &quot;Three columns, three roles. Two wire colors, two node states. One italicized footer per section.&quot;,
+      &quot;guideLayer4ReadingColumns&quot;: &quot;Columns · Objective facets (left) → sections (middle) → invariants (right). Each is a governance role expressed as a column.&quot;,
+      &quot;guideLayer4ReadingWires&quot;: &quot;Wires · Gray bezier = coverage (facet is carried by section). Amber bezier with arrowhead = invariant (rule governs section). Dashed variants signal drift or in-flight preview.&quot;,
+      &quot;guideLayer4ReadingStates&quot;: &quot;States · Pink facet card + Orphan badge = no coverage edges. Dashed red wire = drifted (points at a missing section). Dimmed + desaturated wires = metaFingerprint is stale.&quot;,
+      &quot;guideLayer4ReadingStats&quot;: &quot;Stats bar · Pinned at the top: facet / section / coverage / invariant counts, rationale declared vs total, and loud pills for orphan or drift counts when either is non-zero.&quot;,
+      &quot;guideLayer4ReadingRationale&quot;: &quot;Rationale · Italicized dashed card at the bottom of each section node. A dotted \&quot;no rationale declared yet\&quot; stub appears when the field is missing so authoring gaps stay visible.&quot;,
+      &quot;guideLayer4EditingTitle&quot;: &quot;Editing via the Flow canvas&quot;,
+      &quot;guideLayer4EditingBody&quot;: &quot;Every interaction writes to the same `docExtras` that `/crystallize` and the tabular editor use, so the canvas stays in sync with the other views.&quot;,
+      &quot;guideLayer4EditingDrag&quot;: &quot;Drag a port → create a wire. Facet out-port to section in-port adds coverage (picks an unused cardId from the section). Invariant out-port to section right-port adds that section to `appliesTo`, stripping any existing `\&quot;*\&quot;`.&quot;,
+      &quot;guideLayer4EditingClick&quot;: &quot;Click a wire → remove it. Click the Doc-wide chip on an invariant → toggle doc-wide scope. Click a section&#39;s rationale card → edit the sentence inline via prompt.&quot;,
+      &quot;guideLayer4EditingRemove&quot;: &quot;× on hover → delete a node. Facets cascade their coverage; sections intentionally leave coverage edges behind as drift (the visual signal stays visible); invariants are a clean delete.&quot;,
+      &quot;guideLayer4EditingPosition&quot;: &quot;Drag a node body → reposition on the canvas (`flowPosition` saves to the node). Double-click → return to column. Reset layout button in the stats bar → clear all custom positions.&quot;,
+      &quot;guideLayer4DeepTitle&quot;: &quot;Fingerprint, freshness, and the crystallization moment&quot;,
+      &quot;guideLayer4DeepIntro&quot;: &quot;The fingerprint is cheap to compute and load-bearing. Understanding what it hashes, when to stamp it, and what freshness means turns governance from a static label into a living contract.&quot;,
+      &quot;guideLayer4DeepHashTitle&quot;: &quot;What the fingerprint hashes&quot;,
+      &quot;guideLayer4DeepHashBody&quot;: &quot;A sha256 of each section&#39;s id, convergenceType, and ordered card ids. Stable under prose edits within cards; unstable when sections are added or removed, renamed, or restructured. The choice is deliberate — governance maps to structure, not to content.&quot;,
+      &quot;guideLayer4DeepMomentTitle&quot;: &quot;The crystallization moment&quot;,
+      &quot;guideLayer4DeepMomentBody&quot;: &quot;Think of it as a git commit on the doc&#39;s meaning. Before the stamp, the doc is in shape-discovery mode and governance would calcify bad decompositions. After the stamp, governance pins to an exact structural state. Crystallize when the shape is stable enough that a week of small edits won&#39;t reshape it.&quot;,
+      &quot;guideLayer4DeepStatesTitle&quot;: &quot;Three states, three postures&quot;,
+      &quot;guideLayer4DeepStatesBody&quot;: &quot;Missing — no fingerprint, nothing to check; agents fall back to prose re-derivation. Fresh — stored matches current; agents deterministically target the right cards via coverage edges. Stale — stored differs from current; wires dim and agents must fall back to prose, because coverage may now point at cards whose meaning has shifted.&quot;,
+      &quot;guideLayer4DeepRitualsTitle&quot;: &quot;Stamp vs refresh&quot;,
+      &quot;guideLayer4DeepRitualsBody&quot;: &quot;Stamp (from the Flow banner) — recompute the sha256 and store it. Preserves existing facets, coverage, invariants, and rationale. Use when the structural edit is semantic-neutral (renamed a section you just added, reshuffled a card id). Refresh via `/crystallize &lt;doc&gt; --refresh` — rerun the skill. Proposes updated facets and coverage for the new structure; preserves author-edited fields. Use when the change is genuinely new shape.&quot;,
+      &quot;guideLayer4DeepBridgeTitle&quot;: &quot;Why this bridges authoring and long-term coherence&quot;,
+      &quot;guideLayer4DeepBridgeBody&quot;: &quot;Without a fingerprint, \&quot;is this doc still coherent?\&quot; requires an LLM re-read and human judgment on every pass. With a fingerprint, it&#39;s a hash comparison. That collapse — from judgment to verification — is what turns a living doc from an opinionated structure into a testable substrate. Over time it enables empirical evaluation of which doc shapes actually perform well for human and agent readers alike.&quot;,
       &quot;guideLayer5Title&quot;: &quot;Extending the Vocabulary&quot;,
       &quot;guideLayer5Tagline&quot;: &quot;Creating a new convergence type when nothing fits.&quot;,
       &quot;guideLayer6Title&quot;: &quot;Working with Living Docs&quot;,
@@ -1922,7 +2172,26 @@
       &quot;preview&quot;: &quot;Voorbeeld&quot;,
       &quot;visual&quot;: &quot;Visueel&quot;,
       &quot;board&quot;: &quot;Bord&quot;,
+      &quot;flow&quot;: &quot;Flow&quot;,
       &quot;json&quot;: &quot;JSON&quot;,
+      &quot;flowEmptyTitle&quot;: &quot;Governance-canvas&quot;,
+      &quot;flowEmptyBody&quot;: &quot;De Flow-weergave rendert de governance-laag van het document — doelfacetten, coverage-edges, invarianten en rationale — als canvas. Canvasrendering landt in #47. Het tabblad staat; datastromen volgen.&quot;,
+      &quot;flowMissingGovernance&quot;: &quot;Dit document heeft nog geen governance-data. Draai /crystallize op de JSON om objectiveFacets, coverage en invariants te vullen.&quot;,
+      &quot;flowColFacets&quot;: &quot;Doelfacetten&quot;,
+      &quot;flowColSections&quot;: &quot;Secties&quot;,
+      &quot;flowColInvariants&quot;: &quot;Invarianten&quot;,
+      &quot;flowMetaChecking&quot;: &quot;Versheid van meta controleren…&quot;,
+      &quot;flowMetaCheckingBody&quot;: &quot;Huidige sectievingerafdruk berekenen.&quot;,
+      &quot;flowMetaMissingTitle&quot;: &quot;Meta nog niet gestempeld.&quot;,
+      &quot;flowMetaMissingBody&quot;: &quot;Draai /crystallize om objectiveFacets, coverage, invariants en een metaFingerprint te zaaien zodat drift detecteerbaar wordt.&quot;,
+      &quot;flowMetaStaleTitle&quot;: &quot;Meta is verouderd.&quot;,
+      &quot;flowMetaStaleBody&quot;: &quot;Secties zijn gewijzigd sinds de meta werd afgeleid. Coverage-edges kunnen naar verkeerde kaarten wijzen. Draai /crystallize --refresh of stempel een nieuwe vingerafdruk.&quot;,
+      &quot;flowStampNow&quot;: &quot;Vingerafdruk nu stempelen&quot;,
+      &quot;flowStamping&quot;: &quot;Stempelen…&quot;,
+      &quot;flowStamped&quot;: &quot;Gestempeld&quot;,
+      &quot;flowCrystallize&quot;: &quot;Kopieer /crystallize-prompt&quot;,
+      &quot;flowCrystallizeCopied&quot;: &quot;Gekopieerd&quot;,
+      &quot;flowResetLayout&quot;: &quot;Layout resetten&quot;,
       &quot;templates&quot;: &quot;Templates&quot;,
       &quot;templatesHint&quot;: &quot;Blader door starter- en geavanceerde living-doc-templates&quot;,
       &quot;templatesIntro&quot;: &quot;Begin met een eenvoudige starter-template of spring direct naar een uitgebreidere geavanceerde vorm.&quot;,
@@ -2229,7 +2498,37 @@
       &quot;guideLayer4FingerprintTitle&quot;: &quot;Vingerafdruk en versheid&quot;,
       &quot;guideLayer4FingerprintBody&quot;: &quot;Een sha256 van de sectiestructuur op het moment van uitkristalliseren. Toont een banner wanneer secties zijn verschoven maar de meta niet — verouderde coverage is erger dan geen coverage, dus drift wordt luid.&quot;,
       &quot;guideLayer4CrystallizeTitle&quot;: &quot;Tweede-pass verfijning, geen authoring-gate&quot;,
-      &quot;guideLayer4CrystallizeBody&quot;: &quot;Kristalliseer niet in vroege iteratie — facetten zijn nog niet uitgekristalliseerd. Draai `/crystallize &lt;doc&gt;` zodra de vorm stabiel is; de skill stelt facetten, coverage, invarianten en rationale voor vanuit wat het document al bevat. Herhaal met `--refresh` bij structurele wijziging.&quot;,
+      &quot;guideLayer4CrystallizeBody&quot;: &quot;Kristalliseer niet in vroege iteratie — facetten zijn nog niet uitgekristalliseerd. Draai `/crystallize &lt;doc&gt;` zodra de vorm stabiel is; de skill stelt facetten, coverage, invarianten en rationale voor vanuit wat het document al bevat. Herhaal met `--refresh` bij structurele wijziging. Open het Flow-tabblad om facetten en coverage te zien verschijnen terwijl de skill ze wegschrijft.&quot;,
+      &quot;guideLayer4FlowIntro&quot;: &quot;Het Flow-tabblad in de compositor is het primaire oppervlak voor governance. Open een gekristalliseerd document, schakel over naar Flow, en de laag wordt een canvas: facetten links, secties in het midden, invarianten rechts, met getypeerde draden ertussen.&quot;,
+      &quot;guideLayer4FlowFacets&quot;: &quot;In het Flow-canvas: de linkerkolom. Orphan-facetten verschijnen als roze kaarten met een Orphan-badge, zodat gaten in de coverage in één oogopslag zichtbaar zijn. Sleep de rechterpoort van een facet naar de linkerpoort van een sectie om een coverage-edge toe te voegen.&quot;,
+      &quot;guideLayer4FlowCoverage&quot;: &quot;In het Flow-canvas: grijze bezier-draden van de rechterpoort van elk facet naar de linkerpoort van de sectie. Drift (de doelsectie is verwijderd) verschijnt als een gestreepte rode draad die richting de sectiekolom wegloopt. Klik op een draad om hem te verwijderen.&quot;,
+      &quot;guideLayer4FlowInvariants&quot;: &quot;In het Flow-canvas: de rechterkolom, amberen pijlen met pijlpunten wijzen naar de secties die ze beheren. Klik op de Doc-wide-chip van een invariant om `appliesTo: [\&quot;*\&quot;]` om te schakelen; de pijlen klappen samen in één pijl die wijst naar een virtueel anker boven de sectiekolom. Sleep naar een specifieke sectie om opnieuw te scopen.&quot;,
+      &quot;guideLayer4FlowFingerprint&quot;: &quot;In het Flow-canvas: een amberen banner blijft bovenaan hangen wanneer de vingerafdruk verouderd is. Coverage- en invariant-draden vervagen en desatureren zodat de verouderde staat onmiskenbaar is. De Stempel-knop in de banner herberekent en slaat een nieuwe vingerafdruk op; de Kristalliseer-knop kopieert `/crystallize &lt;doc&gt; --refresh` naar het klembord.&quot;,
+      &quot;guideLayer4ReadingTitle&quot;: &quot;Het Flow-canvas lezen&quot;,
+      &quot;guideLayer4ReadingBody&quot;: &quot;Drie kolommen, drie rollen. Twee draadkleuren, twee knooppunttoestanden. Eén cursieve voettekst per sectie.&quot;,
+      &quot;guideLayer4ReadingColumns&quot;: &quot;Kolommen · Doelfacetten (links) → secties (midden) → invarianten (rechts). Elk is een governance-rol uitgedrukt als kolom.&quot;,
+      &quot;guideLayer4ReadingWires&quot;: &quot;Draden · Grijze bezier = coverage (facet wordt gedragen door sectie). Amberen bezier met pijlpunt = invariant (regel beheert sectie). Gestreepte varianten signaleren drift of in-uitvoering-preview.&quot;,
+      &quot;guideLayer4ReadingStates&quot;: &quot;Toestanden · Roze facetkaart + Orphan-badge = geen coverage-edges. Gestreepte rode draad = gedriftet (wijst naar een ontbrekende sectie). Vervaagde + gedesatureerde draden = metaFingerprint is verouderd.&quot;,
+      &quot;guideLayer4ReadingStats&quot;: &quot;Statusbalk · Vastgeprikt bovenaan: facet / sectie / coverage / invariant-aantallen, aangegeven rationale versus totaal, en opvallende labels voor orphan- of drift-aantallen wanneer die niet nul zijn.&quot;,
+      &quot;guideLayer4ReadingRationale&quot;: &quot;Rationale · Cursieve gestippelde kaart onderaan elk sectieknooppunt. Een gestippelde \&quot;nog geen rationale verklaard\&quot;-stub verschijnt wanneer het veld ontbreekt, zodat hiaten in authoring zichtbaar blijven.&quot;,
+      &quot;guideLayer4EditingTitle&quot;: &quot;Bewerken via het Flow-canvas&quot;,
+      &quot;guideLayer4EditingBody&quot;: &quot;Elke interactie schrijft naar dezelfde `docExtras` die `/crystallize` en de tabulaire editor gebruiken, zodat het canvas synchroon blijft met de andere weergaven.&quot;,
+      &quot;guideLayer4EditingDrag&quot;: &quot;Sleep een poort → maak een draad. Facet-uitpoort naar sectie-inpoort voegt coverage toe (kiest een ongebruikte cardId uit de sectie). Invariant-uitpoort naar sectie-rechterpoort voegt die sectie toe aan `appliesTo`, waarbij een bestaande `\&quot;*\&quot;` wordt verwijderd.&quot;,
+      &quot;guideLayer4EditingClick&quot;: &quot;Klik op een draad → verwijder hem. Klik op de Doc-wide-chip van een invariant → schakel doc-brede scope om. Klik op de rationale-kaart van een sectie → bewerk de zin inline via prompt.&quot;,
+      &quot;guideLayer4EditingRemove&quot;: &quot;× bij hover → verwijder een knooppunt. Facetten cascaderen hun coverage; secties laten coverage-edges opzettelijk achter als drift (het visuele signaal blijft zichtbaar); invarianten zijn een schone verwijdering.&quot;,
+      &quot;guideLayer4EditingPosition&quot;: &quot;Sleep een knooppunt-body → verplaatsen op het canvas (`flowPosition` wordt opgeslagen op het knooppunt). Dubbelklik → terug naar kolom. Layout-reset-knop in de statusbalk → wis alle aangepaste posities.&quot;,
+      &quot;guideLayer4DeepTitle&quot;: &quot;Vingerafdruk, versheid en het kristallisatiemoment&quot;,
+      &quot;guideLayer4DeepIntro&quot;: &quot;De vingerafdruk is goedkoop te berekenen en draagt veel gewicht. Begrijpen wat hij hasht, wanneer je hem stempelt en wat versheid betekent, verandert governance van een statisch etiket in een levend contract.&quot;,
+      &quot;guideLayer4DeepHashTitle&quot;: &quot;Wat de vingerafdruk hasht&quot;,
+      &quot;guideLayer4DeepHashBody&quot;: &quot;Een sha256 van elk sectie-id, convergenceType en de geordende kaart-id&#39;s. Stabiel onder proza-bewerkingen binnen kaarten; instabiel wanneer secties worden toegevoegd of verwijderd, hernoemd of geherstructureerd. De keuze is opzettelijk — governance volgt structuur, geen inhoud.&quot;,
+      &quot;guideLayer4DeepMomentTitle&quot;: &quot;Het kristallisatiemoment&quot;,
+      &quot;guideLayer4DeepMomentBody&quot;: &quot;Beschouw het als een git-commit op de betekenis van het document. Vóór de stempel is het document in vormontdekking en zou governance slechte decomposities uitkristalliseren. Na de stempel is governance vastgepind op een exacte structurele staat. Kristalliseer wanneer de vorm stabiel genoeg is dat een week van kleine bewerkingen hem niet opnieuw vormt.&quot;,
+      &quot;guideLayer4DeepStatesTitle&quot;: &quot;Drie toestanden, drie houdingen&quot;,
+      &quot;guideLayer4DeepStatesBody&quot;: &quot;Ontbrekend — geen vingerafdruk, niets om te controleren; agents vallen terug op proza-herafleiding. Vers — opgeslagen komt overeen met huidig; agents richten deterministisch op de juiste kaarten via coverage-edges. Verouderd — opgeslagen verschilt van huidig; draden vervagen en agents moeten terugvallen op proza omdat coverage naar kaarten kan wijzen waarvan de betekenis is verschoven.&quot;,
+      &quot;guideLayer4DeepRitualsTitle&quot;: &quot;Stempelen vs verversen&quot;,
+      &quot;guideLayer4DeepRitualsBody&quot;: &quot;Stempelen (vanuit de Flow-banner) — bereken de sha256 opnieuw en sla hem op. Behoudt bestaande facetten, coverage, invarianten en rationale. Gebruik wanneer de structurele bewerking semantisch-neutraal is (een sectie die je net toevoegde hernoemd, een kaart-id hergeschikt). Verversen via `/crystallize &lt;doc&gt; --refresh` — draai de skill opnieuw. Stelt bijgewerkte facetten en coverage voor voor de nieuwe structuur; behoudt door auteur bewerkte velden. Gebruik wanneer de wijziging werkelijk nieuwe vorm is.&quot;,
+      &quot;guideLayer4DeepBridgeTitle&quot;: &quot;Waarom dit authoring en langdurige coherentie verbindt&quot;,
+      &quot;guideLayer4DeepBridgeBody&quot;: &quot;Zonder vingerafdruk vereist \&quot;is dit document nog coherent?\&quot; bij elke iteratie een LLM-herleest en menselijk oordeel. Met een vingerafdruk is het een hash-vergelijking. Die ineenstorting — van oordeel naar verificatie — is wat een living doc verandert van een eigengereide structuur in een toetsbaar substraat. In de loop van de tijd maakt het empirische evaluatie mogelijk van welke documentvormen daadwerkelijk goed presteren voor zowel mens als agent.&quot;,
       &quot;guideLayer5Title&quot;: &quot;De Woordenschat Uitbreiden&quot;,
       &quot;guideLayer5Tagline&quot;: &quot;Een nieuw convergentietype maken wanneer niets past.&quot;,
       &quot;guideLayer6Title&quot;: &quot;Werken met Living Docs&quot;,
@@ -2364,7 +2663,26 @@
       &quot;preview&quot;: &quot;Pratinjau&quot;,
       &quot;visual&quot;: &quot;Visual&quot;,
       &quot;board&quot;: &quot;Papan&quot;,
+      &quot;flow&quot;: &quot;Flow&quot;,
       &quot;json&quot;: &quot;JSON&quot;,
+      &quot;flowEmptyTitle&quot;: &quot;Kanvas governance&quot;,
+      &quot;flowEmptyBody&quot;: &quot;Tampilan Flow merender lapisan governance dokumen — faset tujuan, edge coverage, invarian, dan rationale — sebagai kanvas. Rendering kanvas mendarat di #47. Tab sudah ada; aliran data menyusul.&quot;,
+      &quot;flowMissingGovernance&quot;: &quot;Dokumen ini belum memiliki data governance. Jalankan /crystallize pada JSON untuk mengisi objectiveFacets, coverage, dan invariants.&quot;,
+      &quot;flowColFacets&quot;: &quot;Faset tujuan&quot;,
+      &quot;flowColSections&quot;: &quot;Seksi&quot;,
+      &quot;flowColInvariants&quot;: &quot;Invarian&quot;,
+      &quot;flowMetaChecking&quot;: &quot;Memeriksa kesegaran meta…&quot;,
+      &quot;flowMetaCheckingBody&quot;: &quot;Menghitung sidik jari seksi saat ini.&quot;,
+      &quot;flowMetaMissingTitle&quot;: &quot;Meta belum disegel.&quot;,
+      &quot;flowMetaMissingBody&quot;: &quot;Jalankan /crystallize untuk menanam objectiveFacets, coverage, invariants, dan metaFingerprint agar drift dapat dideteksi.&quot;,
+      &quot;flowMetaStaleTitle&quot;: &quot;Meta basi.&quot;,
+      &quot;flowMetaStaleBody&quot;: &quot;Seksi berubah sejak meta diturunkan. Edge coverage mungkin menunjuk ke kartu yang salah. Jalankan /crystallize --refresh atau segel sidik jari baru.&quot;,
+      &quot;flowStampNow&quot;: &quot;Segel sidik jari sekarang&quot;,
+      &quot;flowStamping&quot;: &quot;Menyegel…&quot;,
+      &quot;flowStamped&quot;: &quot;Tersegel&quot;,
+      &quot;flowCrystallize&quot;: &quot;Salin prompt /crystallize&quot;,
+      &quot;flowCrystallizeCopied&quot;: &quot;Tersalin&quot;,
+      &quot;flowResetLayout&quot;: &quot;Reset tata letak&quot;,
       &quot;templates&quot;: &quot;Template&quot;,
       &quot;templatesHint&quot;: &quot;Jelajahi template starter dan lanjutan living doc&quot;,
       &quot;templatesIntro&quot;: &quot;Mulai dengan template starter yang sederhana atau langsung pakai bentuk lanjutan yang lebih lengkap.&quot;,
@@ -2671,7 +2989,37 @@
       &quot;guideLayer4FingerprintTitle&quot;: &quot;Sidik jari dan kesegaran&quot;,
       &quot;guideLayer4FingerprintBody&quot;: &quot;Sebuah sha256 dari struktur seksi pada saat kristalisasi. Merender banner ketika seksi bergeser tetapi meta tidak — coverage basi lebih buruk daripada tanpa coverage, sehingga drift menjadi nyaring.&quot;,
       &quot;guideLayer4CrystallizeTitle&quot;: &quot;Penyempurnaan pass-kedua, bukan gerbang authoring&quot;,
-      &quot;guideLayer4CrystallizeBody&quot;: &quot;Jangan mengkristalkan iterasi awal — faset belum mengendap. Jalankan `/crystallize &lt;doc&gt;` saat bentuk sudah stabil; skill mengusulkan faset, coverage, invarian, dan rationale dari apa yang sudah ada di dokumen. Jalankan ulang dengan `--refresh` saat struktur berubah.&quot;,
+      &quot;guideLayer4CrystallizeBody&quot;: &quot;Jangan mengkristalkan iterasi awal — faset belum mengendap. Jalankan `/crystallize &lt;doc&gt;` saat bentuk sudah stabil; skill mengusulkan faset, coverage, invarian, dan rationale dari apa yang sudah ada di dokumen. Jalankan ulang dengan `--refresh` saat struktur berubah. Buka tab Flow untuk melihat faset dan coverage muncul saat skill menuliskannya.&quot;,
+      &quot;guideLayer4FlowIntro&quot;: &quot;Tab Flow di compositor adalah permukaan utama untuk governance. Buka dokumen yang sudah dikristalkan, beralih ke Flow, dan lapisan tersebut menjadi kanvas: faset di kiri, seksi di tengah, invarian di kanan, dengan kabel bertipe di antara mereka.&quot;,
+      &quot;guideLayer4FlowFacets&quot;: &quot;Di kanvas Flow: kolom kiri. Faset orphan dirender sebagai kartu merah muda dengan badge Orphan, sehingga celah dalam coverage terlihat sekilas. Seret port kanan faset ke port kiri seksi untuk menambahkan edge coverage.&quot;,
+      &quot;guideLayer4FlowCoverage&quot;: &quot;Di kanvas Flow: kabel bezier abu-abu dari port kanan setiap faset ke port kiri seksi. Drift (seksi target telah dihapus) muncul sebagai kabel putus-putus merah yang mengarah ke kolom seksi. Klik kabel untuk menghapusnya.&quot;,
+      &quot;guideLayer4FlowInvariants&quot;: &quot;Di kanvas Flow: kolom kanan, panah berwarna kuning kecoklatan dengan kepala panah menunjuk ke seksi yang mereka atur. Klik chip Doc-wide pada invarian untuk beralih `appliesTo: [\&quot;*\&quot;]`; panah-panah itu berkumpul menjadi satu panah yang menunjuk ke jangkar virtual di atas kolom seksi. Seret ke seksi tertentu untuk mengubah cakupan.&quot;,
+      &quot;guideLayer4FlowFingerprint&quot;: &quot;Di kanvas Flow: banner berwarna kuning kecoklatan menempel di atas saat sidik jari basi. Kabel coverage dan invarian meredup dan desaturasi sehingga kondisi basi tak terbantahkan. Tombol Segel di banner menghitung ulang dan menyimpan sidik jari baru; tombol Crystallize menyalin `/crystallize &lt;doc&gt; --refresh` ke clipboard.&quot;,
+      &quot;guideLayer4ReadingTitle&quot;: &quot;Membaca kanvas Flow&quot;,
+      &quot;guideLayer4ReadingBody&quot;: &quot;Tiga kolom, tiga peran. Dua warna kabel, dua kondisi node. Satu footer miring per seksi.&quot;,
+      &quot;guideLayer4ReadingColumns&quot;: &quot;Kolom · Faset tujuan (kiri) → seksi (tengah) → invarian (kanan). Setiap kolom adalah peran governance yang diungkapkan sebagai kolom.&quot;,
+      &quot;guideLayer4ReadingWires&quot;: &quot;Kabel · Bezier abu-abu = coverage (faset dibawa oleh seksi). Bezier kuning kecoklatan dengan kepala panah = invarian (aturan mengatur seksi). Varian putus-putus menandakan drift atau pratinjau dalam progres.&quot;,
+      &quot;guideLayer4ReadingStates&quot;: &quot;Kondisi · Kartu faset merah muda + badge Orphan = tidak ada edge coverage. Kabel putus-putus merah = drift (menunjuk ke seksi yang hilang). Kabel yang meredup + desaturasi = metaFingerprint basi.&quot;,
+      &quot;guideLayer4ReadingStats&quot;: &quot;Bilah stats · Dipatri di atas: jumlah faset / seksi / coverage / invarian, rationale yang dinyatakan vs total, dan pil mencolok untuk jumlah orphan atau drift bila tidak nol.&quot;,
+      &quot;guideLayer4ReadingRationale&quot;: &quot;Rationale · Kartu miring bergaris di bagian bawah setiap node seksi. Stub putus-putus \&quot;belum ada rationale yang dinyatakan\&quot; muncul saat field kosong sehingga celah authoring tetap terlihat.&quot;,
+      &quot;guideLayer4EditingTitle&quot;: &quot;Menyunting lewat kanvas Flow&quot;,
+      &quot;guideLayer4EditingBody&quot;: &quot;Setiap interaksi menulis ke `docExtras` yang sama yang digunakan oleh `/crystallize` dan editor tabulasi, sehingga kanvas tetap sinkron dengan tampilan lain.&quot;,
+      &quot;guideLayer4EditingDrag&quot;: &quot;Seret port → buat kabel. Port-keluar faset ke port-masuk seksi menambahkan coverage (memilih cardId yang belum terpakai dari seksi). Port-keluar invarian ke port-kanan seksi menambahkan seksi itu ke `appliesTo`, menghapus `\&quot;*\&quot;` yang ada.&quot;,
+      &quot;guideLayer4EditingClick&quot;: &quot;Klik kabel → hapus. Klik chip Doc-wide pada invarian → alihkan cakupan doc-wide. Klik kartu rationale seksi → sunting kalimat inline via prompt.&quot;,
+      &quot;guideLayer4EditingRemove&quot;: &quot;× pada hover → hapus node. Faset mencascade coverage-nya; seksi sengaja meninggalkan edge coverage sebagai drift (sinyal visualnya tetap terlihat); invarian adalah penghapusan bersih.&quot;,
+      &quot;guideLayer4EditingPosition&quot;: &quot;Seret body node → reposisi di kanvas (`flowPosition` tersimpan di node). Klik ganda → kembali ke kolom. Tombol reset tata letak di bilah stats → hapus semua posisi khusus.&quot;,
+      &quot;guideLayer4DeepTitle&quot;: &quot;Sidik jari, kesegaran, dan momen kristalisasi&quot;,
+      &quot;guideLayer4DeepIntro&quot;: &quot;Sidik jari murah untuk dihitung dan memikul banyak beban. Memahami apa yang di-hash, kapan menyegelnya, dan apa arti kesegaran mengubah governance dari label statis menjadi kontrak hidup.&quot;,
+      &quot;guideLayer4DeepHashTitle&quot;: &quot;Apa yang di-hash oleh sidik jari&quot;,
+      &quot;guideLayer4DeepHashBody&quot;: &quot;Sebuah sha256 dari setiap id seksi, convergenceType, dan id kartu yang berurutan. Stabil terhadap suntingan prosa di dalam kartu; tidak stabil ketika seksi ditambahkan atau dihapus, diganti nama, atau direstrukturisasi. Pilihannya disengaja — governance mengikuti struktur, bukan konten.&quot;,
+      &quot;guideLayer4DeepMomentTitle&quot;: &quot;Momen kristalisasi&quot;,
+      &quot;guideLayer4DeepMomentBody&quot;: &quot;Anggap ini seperti git commit pada makna dokumen. Sebelum penyegelan, dokumen dalam mode penemuan bentuk dan governance akan mengkristalkan dekomposisi yang buruk. Setelah penyegelan, governance terpaku pada kondisi struktural yang tepat. Kristalkan saat bentuk sudah cukup stabil sehingga seminggu suntingan kecil tidak akan mengubah bentuknya.&quot;,
+      &quot;guideLayer4DeepStatesTitle&quot;: &quot;Tiga kondisi, tiga sikap&quot;,
+      &quot;guideLayer4DeepStatesBody&quot;: &quot;Hilang — tidak ada sidik jari, tidak ada yang diperiksa; agen kembali ke penurunan prosa. Segar — tersimpan cocok dengan saat ini; agen secara deterministik menargetkan kartu yang tepat via edge coverage. Basi — tersimpan berbeda dari saat ini; kabel meredup dan agen harus kembali ke prosa karena coverage mungkin menunjuk ke kartu yang maknanya telah bergeser.&quot;,
+      &quot;guideLayer4DeepRitualsTitle&quot;: &quot;Segel vs segarkan&quot;,
+      &quot;guideLayer4DeepRitualsBody&quot;: &quot;Segel (dari banner Flow) — hitung ulang sha256 dan simpan. Mempertahankan faset, coverage, invarian, dan rationale yang ada. Gunakan ketika suntingan struktural netral-semantik (nama seksi yang baru saja ditambahkan, id kartu yang diatur ulang). Segarkan via `/crystallize &lt;doc&gt; --refresh` — jalankan ulang skill. Mengusulkan faset dan coverage yang diperbarui untuk struktur baru; mempertahankan field yang disunting penulis. Gunakan ketika perubahan benar-benar bentuk baru.&quot;,
+      &quot;guideLayer4DeepBridgeTitle&quot;: &quot;Mengapa ini menjembatani authoring dan koherensi jangka panjang&quot;,
+      &quot;guideLayer4DeepBridgeBody&quot;: &quot;Tanpa sidik jari, pertanyaan \&quot;apakah dokumen ini masih koheren?\&quot; membutuhkan pembacaan ulang LLM dan penilaian manusia pada setiap iterasi. Dengan sidik jari, ini adalah perbandingan hash. Pelipatan itu — dari penilaian ke verifikasi — yang mengubah living doc dari struktur beropini menjadi substrat yang dapat diuji. Seiring waktu memungkinkan evaluasi empiris terhadap bentuk dokumen mana yang benar-benar bekerja baik untuk pembaca manusia maupun agen.&quot;,
       &quot;guideLayer5Title&quot;: &quot;Memperluas Kosakata&quot;,
       &quot;guideLayer5Tagline&quot;: &quot;Membuat tipe konvergensi baru ketika yang ada tidak cocok.&quot;,
       &quot;guideLayer6Title&quot;: &quot;Bekerja dengan Living Docs&quot;,
@@ -2876,10 +3224,13 @@
     return String(value || &#39;&#39;).toLowerCase().replace(/[^a-z0-9]+/g, &#39;-&#39;).replace(/^-|-$/g, &#39;&#39;).slice(0, 64);
   }
   function govSectionSignature() {
+    // Key names must match scripts/meta-fingerprint.mjs exactly — the Node
+    // stamper and this browser check produce different sha256 hashes otherwise,
+    // and every crystallized doc reads as stale in the Flow view. See #58.
     return JSON.stringify((state.sections || []).map((s) =&gt; ({
       id: String(s?.id || &#39;&#39;),
-      t: String(s?.convergenceType || &#39;&#39;),
-      c: (Array.isArray(s?.data) ? s.data : []).map((item) =&gt; String(item?.id || &#39;&#39;)).filter(Boolean),
+      type: String(s?.convergenceType || &#39;&#39;),
+      cards: (Array.isArray(s?.data) ? s.data : []).map((item) =&gt; String(item?.id || &#39;&#39;)).filter(Boolean),
     })));
   }
   async function govComputeFingerprint() {
@@ -9251,7 +9602,7 @@
     autoSave();
     const panel = document.getElementById(&#39;right-panel&#39;);
 
-    if (![&#39;visual&#39;, &#39;board&#39;, &#39;json&#39;].includes(state.previewTab)) state.previewTab = &#39;visual&#39;;
+    if (![&#39;visual&#39;, &#39;board&#39;, &#39;flow&#39;, &#39;json&#39;].includes(state.previewTab)) state.previewTab = &#39;visual&#39;;
     const json = buildJson();
     const title = t(&#39;preview&#39;);
 
@@ -9261,15 +9612,18 @@
         &lt;div class=&quot;preview-tabs&quot;&gt;
           &lt;button class=&quot;preview-tab${state.previewTab === &#39;visual&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;visual&quot;&gt;${esc(t(&#39;visual&#39;))}&lt;/button&gt;
           &lt;button class=&quot;preview-tab${state.previewTab === &#39;board&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;board&quot;&gt;${esc(t(&#39;board&#39;))}&lt;/button&gt;
+          &lt;button class=&quot;preview-tab${state.previewTab === &#39;flow&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;flow&quot;&gt;${esc(t(&#39;flow&#39;))}&lt;/button&gt;
           &lt;button class=&quot;preview-tab${state.previewTab === &#39;json&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;json&quot;&gt;${esc(t(&#39;json&#39;))}&lt;/button&gt;
         &lt;/div&gt;
       &lt;/div&gt;
-      &lt;div class=&quot;preview-content&quot;&gt;
+      &lt;div class=&quot;preview-content${state.previewTab === &#39;flow&#39; ? &#39; preview-content-flow&#39; : &#39;&#39;}&quot;&gt;
         ${state.previewTab === &#39;json&#39;
           ? renderJsonPreview(json)
           : state.previewTab === &#39;board&#39;
             ? renderBoardPreview(json)
-            : renderVisualPreview(json)}
+            : state.previewTab === &#39;flow&#39;
+              ? renderFlowPreview(json)
+              : renderVisualPreview(json)}
       &lt;/div&gt;`;
 
     panel.querySelectorAll(&#39;.preview-tab&#39;).forEach(tab =&gt; {
@@ -9507,8 +9861,344 @@
       refreshFingerprintPill();
     }
 
+    if (state.previewTab === &#39;flow&#39;) {
+      requestAnimationFrame(() =&gt; drawFlowWires(json));
+      wireFlowInteractions(panel);
+    }
+
     syncFocusedSectionInPreview();
   }
+
+  let flowResizeHandler = null;
+  function ensureFlowResizeHook() {
+    if (flowResizeHandler) return;
+    flowResizeHandler = () =&gt; {
+      if (state.previewTab !== &#39;flow&#39;) return;
+      requestAnimationFrame(() =&gt; drawFlowWires(buildJson()));
+    };
+    window.addEventListener(&#39;resize&#39;, flowResizeHandler);
+  }
+  ensureFlowResizeHook();
+
+  function flowRerender() {
+    autoSave();
+    renderRight();
+  }
+
+  function wireFlowInteractions(panel) {
+    const canvas = panel.querySelector(&#39;#flow-canvas&#39;);
+    const wrap = panel.querySelector(&#39;#flow-canvas-wrap&#39;);
+    if (!canvas || !wrap) return;
+
+    // Remove a node (facet / section / invariant)
+    canvas.querySelectorAll(&#39;[data-flow-remove]&#39;).forEach((btn) =&gt; {
+      btn.addEventListener(&#39;click&#39;, (event) =&gt; {
+        event.stopPropagation();
+        const kind = btn.dataset.flowRemove;
+        const id = btn.dataset.flowId;
+        if (kind === &#39;facet&#39;) {
+          govSetFacets(govFacets().filter((f) =&gt; f.id !== id));
+          govSetCoverage(govCoverage().filter((c) =&gt; c.facetId !== id));
+        } else if (kind === &#39;invariant&#39;) {
+          govSetInvariants(govInvariants().filter((i) =&gt; i.id !== id));
+        } else if (kind === &#39;section&#39;) {
+          state.sections = state.sections.filter((s) =&gt; s.id !== id);
+          // coverage edges to the removed section become drift — keep them.
+        }
+        flowRerender();
+      });
+    });
+
+    // Remove a wire (coverage or invariant applies-to entry) via delegation,
+    // because wires are drawn async via requestAnimationFrame after this runs.
+    canvas.addEventListener(&#39;click&#39;, (event) =&gt; {
+      const hit = event.target.closest(&#39;[data-flow-edge]&#39;);
+      if (!hit) return;
+      const edgeKind = hit.dataset.flowEdge;
+      if (edgeKind === &#39;coverage&#39;) {
+        const idx = Number(hit.dataset.flowEdgeIndex);
+        const coverage = [...govCoverage()];
+        coverage.splice(idx, 1);
+        govSetCoverage(coverage);
+      } else if (edgeKind === &#39;invariant&#39;) {
+        const invIdx = Number(hit.dataset.flowInvIndex);
+        const tgtIdx = Number(hit.dataset.flowTargetIndex);
+        const invariants = [...govInvariants()];
+        if (invariants[invIdx] &amp;&amp; Array.isArray(invariants[invIdx].appliesTo)) {
+          invariants[invIdx] = {
+            ...invariants[invIdx],
+            appliesTo: invariants[invIdx].appliesTo.filter((_, i) =&gt; i !== tgtIdx),
+          };
+          govSetInvariants(invariants);
+        }
+      }
+      flowRerender();
+    });
+
+    // Toggle doc-wide invariant
+    canvas.querySelectorAll(&#39;[data-flow-docwide]&#39;).forEach((btn) =&gt; {
+      btn.addEventListener(&#39;click&#39;, (event) =&gt; {
+        event.stopPropagation();
+        const invId = btn.dataset.flowDocwide;
+        const invariants = [...govInvariants()];
+        const idx = invariants.findIndex((i) =&gt; i.id === invId);
+        if (idx &lt; 0) return;
+        const applies = Array.isArray(invariants[idx].appliesTo) ? [...invariants[idx].appliesTo] : [];
+        const hasStar = applies.includes(&#39;*&#39;);
+        invariants[idx] = {
+          ...invariants[idx],
+          appliesTo: hasStar ? applies.filter((a) =&gt; a !== &#39;*&#39;) : [&#39;*&#39;],
+        };
+        govSetInvariants(invariants);
+        flowRerender();
+      });
+    });
+
+    // Inline-edit rationale
+    canvas.querySelectorAll(&#39;.flow-rationale&#39;).forEach((el) =&gt; {
+      el.addEventListener(&#39;click&#39;, (event) =&gt; {
+        event.stopPropagation();
+        const sectionNode = el.closest(&#39;[data-flow-kind=&quot;section&quot;]&#39;);
+        if (!sectionNode) return;
+        const sid = sectionNode.dataset.flowId;
+        const section = state.sections.find((s) =&gt; s.id === sid);
+        if (!section) return;
+        const next = window.prompt(&#39;Rationale \u2014 why this convergence type, here:&#39;, section.rationale || &#39;&#39;);
+        if (next === null) return;
+        const trimmed = next.trim();
+        if (trimmed) section.rationale = trimmed; else delete section.rationale;
+        flowRerender();
+      });
+    });
+
+    // Freshness banner — async fingerprint check after render.
+    const banner = panel.querySelector(&#39;#flow-banner&#39;);
+    const stamp = panel.querySelector(&#39;[data-flow-stamp]&#39;);
+    const crystBtn = panel.querySelector(&#39;[data-flow-crystallize]&#39;);
+    const bannerTitle = panel.querySelector(&#39;#flow-banner-title&#39;);
+    const bannerMsg = panel.querySelector(&#39;#flow-banner-message&#39;);
+    const applyBannerState = async () =&gt; {
+      if (!banner || !wrap) return;
+      const stored = govFingerprint();
+      if (!stored) {
+        banner.dataset.state = &#39;missing&#39;;
+        wrap.classList.remove(&#39;flow-stale&#39;);
+        bannerTitle.textContent = t(&#39;flowMetaMissingTitle&#39;);
+        bannerMsg.textContent = t(&#39;flowMetaMissingBody&#39;);
+        return;
+      }
+      const current = await govComputeFingerprint();
+      if (!current || current === stored) {
+        banner.dataset.state = &#39;fresh&#39;;
+        banner.style.display = &#39;none&#39;;
+        wrap.classList.remove(&#39;flow-stale&#39;);
+        return;
+      }
+      banner.dataset.state = &#39;stale&#39;;
+      banner.style.display = &#39;&#39;;
+      wrap.classList.add(&#39;flow-stale&#39;);
+      bannerTitle.textContent = t(&#39;flowMetaStaleTitle&#39;);
+      bannerMsg.textContent = t(&#39;flowMetaStaleBody&#39;);
+    };
+    if (banner) {
+      banner.style.display = &#39;&#39;;
+      applyBannerState();
+    }
+
+    stamp?.addEventListener(&#39;click&#39;, async (event) =&gt; {
+      const btn = event.currentTarget;
+      const original = btn.textContent;
+      btn.disabled = true;
+      btn.textContent = t(&#39;flowStamping&#39;);
+      try {
+        const fp = await govComputeFingerprint();
+        if (fp) {
+          govSetFingerprint(fp);
+          btn.textContent = t(&#39;flowStamped&#39;);
+          setTimeout(() =&gt; { btn.disabled = false; btn.textContent = original; flowRerender(); }, 900);
+        } else {
+          btn.textContent = original;
+          btn.disabled = false;
+        }
+      } catch (err) {
+        btn.textContent = original;
+        btn.disabled = false;
+      }
+    });
+
+    crystBtn?.addEventListener(&#39;click&#39;, async (event) =&gt; {
+      const btn = event.currentTarget;
+      const label = currentOriginLabel() || &#39;&lt;path/to/doc.json&gt;&#39;;
+      const isStale = banner?.dataset.state === &#39;stale&#39;;
+      const prompt = `/crystallize ${label}${isStale ? &#39; --refresh&#39; : &#39;&#39;}`;
+      const original = btn.textContent;
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(prompt);
+          btn.textContent = t(&#39;flowCrystallizeCopied&#39;);
+        } else {
+          window.prompt(&#39;Copy this prompt:&#39;, prompt);
+        }
+      } catch (err) {
+        window.prompt(&#39;Copy this prompt:&#39;, prompt);
+      }
+      setTimeout(() =&gt; { btn.textContent = original; }, 1600);
+    });
+
+    // Reset-layout button
+    panel.querySelector(&#39;[data-flow-reset-layout]&#39;)?.addEventListener(&#39;click&#39;, () =&gt; {
+      const facets = govFacets().map(({ flowPosition, ...rest }) =&gt; rest);
+      const invariants = govInvariants().map(({ flowPosition, ...rest }) =&gt; rest);
+      govSetFacets(facets);
+      govSetInvariants(invariants);
+      state.sections = state.sections.map(({ flowPosition, ...rest }) =&gt; rest);
+      flowRerender();
+    });
+
+    // Double-click a node to clear its flowPosition
+    canvas.querySelectorAll(&#39;.flow-node&#39;).forEach((node) =&gt; {
+      node.addEventListener(&#39;dblclick&#39;, (event) =&gt; {
+        if (event.target.closest(&#39;.flow-port, .flow-remove, [data-flow-docwide], .flow-rationale, [data-flow-reset-layout]&#39;)) return;
+        const kind = node.dataset.flowKind;
+        const id = node.dataset.flowId;
+        if (kind === &#39;facet&#39;) {
+          govSetFacets(govFacets().map((f) =&gt; f.id === id ? (({ flowPosition, ...r }) =&gt; r)(f) : f));
+        } else if (kind === &#39;invariant&#39;) {
+          govSetInvariants(govInvariants().map((i) =&gt; i.id === id ? (({ flowPosition, ...r }) =&gt; r)(i) : i));
+        } else if (kind === &#39;section&#39;) {
+          state.sections = state.sections.map((s) =&gt; s.id === id ? (({ flowPosition, ...r }) =&gt; r)(s) : s);
+        }
+        flowRerender();
+      });
+    });
+
+    // Drag a node body to reposition. Threshold distinguishes drag from click.
+    canvas.querySelectorAll(&#39;.flow-node&#39;).forEach((node) =&gt; {
+      node.addEventListener(&#39;pointerdown&#39;, (event) =&gt; {
+        if (event.target.closest(&#39;.flow-port, .flow-remove, [data-flow-docwide], .flow-rationale, [data-flow-reset-layout]&#39;)) return;
+        if (event.target.closest(&#39;[data-flow-edge]&#39;)) return;
+        event.preventDefault();
+        const canvasRect = canvas.getBoundingClientRect();
+        const nodeRect = node.getBoundingClientRect();
+        const offX = event.clientX - nodeRect.left;
+        const offY = event.clientY - nodeRect.top;
+        const startClientX = event.clientX;
+        const startClientY = event.clientY;
+        let dragging = false;
+        const onMove = (ev) =&gt; {
+          const dx = ev.clientX - startClientX;
+          const dy = ev.clientY - startClientY;
+          if (!dragging &amp;&amp; Math.hypot(dx, dy) &lt; 4) return;
+          dragging = true;
+          const currentCanvasRect = canvas.getBoundingClientRect();
+          const x = Math.max(0, ev.clientX - currentCanvasRect.left - offX);
+          const y = Math.max(0, ev.clientY - currentCanvasRect.top - offY);
+          node.classList.add(&#39;flow-node-dragging&#39;);
+          node.dataset.flowPositioned = &#39;true&#39;;
+          node.style.left = x + &#39;px&#39;;
+          node.style.top = y + &#39;px&#39;;
+          requestAnimationFrame(() =&gt; drawFlowWires(buildJson()));
+        };
+        const onUp = (ev) =&gt; {
+          document.removeEventListener(&#39;pointermove&#39;, onMove);
+          document.removeEventListener(&#39;pointerup&#39;, onUp);
+          node.classList.remove(&#39;flow-node-dragging&#39;);
+          if (!dragging) return;
+          const finalRect = node.getBoundingClientRect();
+          const finalCanvasRect = canvas.getBoundingClientRect();
+          const x = Math.round(finalRect.left - finalCanvasRect.left);
+          const y = Math.round(finalRect.top - finalCanvasRect.top);
+          const kind = node.dataset.flowKind;
+          const id = node.dataset.flowId;
+          if (kind === &#39;facet&#39;) {
+            govSetFacets(govFacets().map((f) =&gt; f.id === id ? { ...f, flowPosition: { x, y } } : f));
+          } else if (kind === &#39;invariant&#39;) {
+            govSetInvariants(govInvariants().map((i) =&gt; i.id === id ? { ...i, flowPosition: { x, y } } : i));
+          } else if (kind === &#39;section&#39;) {
+            state.sections = state.sections.map((s) =&gt; s.id === id ? { ...s, flowPosition: { x, y } } : s);
+          }
+          flowRerender();
+        };
+        document.addEventListener(&#39;pointermove&#39;, onMove);
+        document.addEventListener(&#39;pointerup&#39;, onUp);
+      });
+    });
+
+    // Drag to create a wire
+    canvas.querySelectorAll(&#39;[data-port=&quot;facet-out&quot;]&#39;).forEach((port) =&gt; {
+      port.addEventListener(&#39;pointerdown&#39;, (event) =&gt; {
+        event.preventDefault();
+        flowDragState = { kind: &#39;coverage&#39;, fromId: port.dataset.facetId, mouseX: event.clientX, mouseY: event.clientY };
+        port.classList.add(&#39;flow-port-dragging&#39;);
+        drawFlowWires(buildJson());
+      });
+    });
+    canvas.querySelectorAll(&#39;[data-port=&quot;inv-out&quot;]&#39;).forEach((port) =&gt; {
+      port.addEventListener(&#39;pointerdown&#39;, (event) =&gt; {
+        event.preventDefault();
+        flowDragState = { kind: &#39;invariant&#39;, fromId: port.dataset.invariantId, mouseX: event.clientX, mouseY: event.clientY };
+        port.classList.add(&#39;flow-port-dragging-inv&#39;);
+        drawFlowWires(buildJson());
+      });
+    });
+  }
+
+  // Global pointer handlers for the drag — simpler to keep on document.
+  let flowGlobalPointerHandlers = null;
+  function ensureFlowGlobalPointerHandlers() {
+    if (flowGlobalPointerHandlers) return;
+    flowGlobalPointerHandlers = {
+      move: (event) =&gt; {
+        if (!flowDragState) return;
+        flowDragState.mouseX = event.clientX;
+        flowDragState.mouseY = event.clientY;
+        drawFlowWires(buildJson());
+      },
+      up: (event) =&gt; {
+        if (!flowDragState) return;
+        document.querySelectorAll(&#39;.flow-port.flow-port-dragging, .flow-port.flow-port-dragging-inv&#39;)
+          .forEach((el) =&gt; el.classList.remove(&#39;flow-port-dragging&#39;, &#39;flow-port-dragging-inv&#39;));
+        const drag = flowDragState;
+        flowDragState = null;
+        const dropTarget = document.elementFromPoint(event.clientX, event.clientY);
+        if (drag.kind === &#39;coverage&#39;) {
+          const inPort = dropTarget?.closest(&#39;[data-port=&quot;section-in&quot;]&#39;);
+          if (inPort) {
+            const sectionId = inPort.dataset.sectionId;
+            const facetId = drag.fromId;
+            const section = state.sections.find((s) =&gt; s.id === sectionId);
+            const usedCards = new Set(govCoverage().filter((c) =&gt; c.sectionId === sectionId).map((c) =&gt; c.cardId));
+            const cardId = (section?.data || []).map((d) =&gt; d?.id).filter(Boolean).find((c) =&gt; !usedCards.has(c))
+              || (section?.data || []).map((d) =&gt; d?.id).filter(Boolean)[0]
+              || &#39;&#39;;
+            const exists = govCoverage().some((c) =&gt; c.facetId === facetId &amp;&amp; c.sectionId === sectionId &amp;&amp; (c.cardId || &#39;&#39;) === cardId);
+            if (!exists) {
+              govSetCoverage([...govCoverage(), cardId ? { facetId, sectionId, cardId } : { facetId, sectionId }]);
+            }
+          }
+        } else if (drag.kind === &#39;invariant&#39;) {
+          const invInPort = dropTarget?.closest(&#39;[data-port=&quot;section-inv-in&quot;]&#39;);
+          if (invInPort) {
+            const sectionId = invInPort.dataset.sectionId;
+            const invariants = [...govInvariants()];
+            const idx = invariants.findIndex((i) =&gt; i.id === drag.fromId);
+            if (idx &gt;= 0) {
+              const applies = Array.isArray(invariants[idx].appliesTo) ? [...invariants[idx].appliesTo] : [];
+              const starIdx = applies.indexOf(&#39;*&#39;);
+              if (starIdx &gt;= 0) applies.splice(starIdx, 1);
+              if (!applies.includes(sectionId)) applies.push(sectionId);
+              invariants[idx] = { ...invariants[idx], appliesTo: applies };
+              govSetInvariants(invariants);
+            }
+          }
+        }
+        flowRerender();
+      },
+    };
+    document.addEventListener(&#39;pointermove&#39;, flowGlobalPointerHandlers.move);
+    document.addEventListener(&#39;pointerup&#39;,   flowGlobalPointerHandlers.up);
+  }
+  ensureFlowGlobalPointerHandlers();
 
   function renderTemplatesView() {
     if (!TEMPLATES.length) {
@@ -9589,6 +10279,261 @@
         ${renderTemplateGroup(&#39;starterTemplates&#39;, &#39;starterTemplatesIntro&#39;, starterTemplates)}
         ${renderTemplateGroup(&#39;advancedTemplates&#39;, &#39;advancedTemplatesIntro&#39;, advancedTemplates)}
       &lt;/div&gt;`;
+  }
+
+  function deriveFlowCoherence(json) {
+    const facets = Array.isArray(json.objectiveFacets) ? json.objectiveFacets : [];
+    const coverage = Array.isArray(json.coverage) ? json.coverage : [];
+    const invariants = Array.isArray(json.invariants) ? json.invariants : [];
+    const sections = Array.isArray(json.sections) ? json.sections : [];
+    const knownSectionIds = new Set(sections.map((s) =&gt; s.id));
+    const facetStatus = new Map();
+    for (const facet of facets) {
+      const edges = coverage.filter((c) =&gt; c.facetId === facet.id);
+      const carryingSectionIds = [...new Set(edges.map((e) =&gt; e.sectionId))];
+      const anyDrift = edges.some((e) =&gt; !knownSectionIds.has(e.sectionId));
+      let status;
+      if (anyDrift) status = &#39;drift&#39;;
+      else if (edges.length === 0) status = &#39;orphaned&#39;;
+      else status = &#39;covered&#39;;
+      facetStatus.set(facet.id, { status, carryingSectionIds });
+    }
+    return { facets, coverage, invariants, sections, knownSectionIds, facetStatus };
+  }
+
+  function renderFlowPreview(json) {
+    const state = deriveFlowCoherence(json);
+    const { facets, coverage, invariants, sections } = state;
+    const hasGovernance = facets.length &gt; 0 || coverage.length &gt; 0 || invariants.length &gt; 0;
+
+    if (!hasGovernance) {
+      return `
+        &lt;div class=&quot;flow-empty&quot;&gt;
+          &lt;strong&gt;${esc(t(&#39;flowEmptyTitle&#39;))}&lt;/strong&gt;
+          ${esc(t(&#39;flowMissingGovernance&#39;))}
+        &lt;/div&gt;`;
+    }
+
+    const orphanCount = [...state.facetStatus.values()].filter((v) =&gt; v.status === &#39;orphaned&#39;).length;
+    const driftCount = [...state.facetStatus.values()].filter((v) =&gt; v.status === &#39;drift&#39;).length;
+    const rationalesDeclared = sections.filter((s) =&gt; (s.rationale || &#39;&#39;).trim().length &gt; 0).length;
+    const invArrows = invariants.reduce((n, inv) =&gt; n + (Array.isArray(inv.appliesTo) ? inv.appliesTo.length : 0), 0);
+
+    const anyPositioned =
+      facets.some((f) =&gt; f.flowPosition) ||
+      sections.some((s) =&gt; s.flowPosition) ||
+      invariants.some((i) =&gt; i.flowPosition);
+
+    const statsHtml = `
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${facets.length}&lt;/strong&gt; facets&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${sections.length}&lt;/strong&gt; sections&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${coverage.length}&lt;/strong&gt; coverage edges&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${invariants.length}&lt;/strong&gt; invariants \u00b7 ${invArrows} arrows&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${rationalesDeclared}/${sections.length}&lt;/strong&gt; rationales&lt;/span&gt;
+      ${orphanCount &gt; 0 ? `&lt;span class=&quot;flow-stat flow-stat-bad&quot;&gt;&lt;strong&gt;${orphanCount}&lt;/strong&gt; orphaned&lt;/span&gt;` : &#39;&#39;}
+      ${driftCount &gt; 0 ? `&lt;span class=&quot;flow-stat flow-stat-warn&quot;&gt;&lt;strong&gt;${driftCount}&lt;/strong&gt; drifted&lt;/span&gt;` : &#39;&#39;}
+      ${anyPositioned ? `&lt;button type=&quot;button&quot; class=&quot;flow-reset-layout-btn&quot; data-flow-reset-layout title=&quot;Clear all flowPosition values&quot;&gt;${esc(t(&#39;flowResetLayout&#39;))}&lt;/button&gt;` : &#39;&#39;}`;
+
+    const positionStyle = (node) =&gt; {
+      const p = node?.flowPosition;
+      if (!p || typeof p !== &#39;object&#39;) return &#39;&#39;;
+      const x = Number.isFinite(p.x) ? p.x : 0;
+      const y = Number.isFinite(p.y) ? p.y : 0;
+      return ` data-flow-positioned=&quot;true&quot; style=&quot;left:${x}px;top:${y}px&quot;`;
+    };
+
+    const facetsHtml = facets.map((facet) =&gt; {
+      const { status } = state.facetStatus.get(facet.id) || { status: &#39;orphaned&#39; };
+      const orphan = status === &#39;orphaned&#39;;
+      return `
+        &lt;article class=&quot;flow-node ${orphan ? &#39;flow-node-orphan&#39; : &#39;&#39;}&quot; data-flow-kind=&quot;facet&quot; data-flow-id=&quot;${esc(facet.id)}&quot;${positionStyle(facet)}&gt;
+          &lt;button type=&quot;button&quot; class=&quot;flow-remove&quot; data-flow-remove=&quot;facet&quot; data-flow-id=&quot;${esc(facet.id)}&quot; title=&quot;Remove facet&quot;&gt;\u00d7&lt;/button&gt;
+          &lt;div class=&quot;flow-node-header&quot;&gt;
+            &lt;h5&gt;${esc(facet.name || facet.id)}&lt;/h5&gt;
+            ${orphan ? `&lt;span class=&quot;flow-badge flow-badge-orphan&quot;&gt;Orphan&lt;/span&gt;` : &#39;&#39;}
+          &lt;/div&gt;
+          &lt;div class=&quot;flow-node-id&quot;&gt;${esc(facet.id)}&lt;/div&gt;
+          ${facet.description ? `&lt;div class=&quot;flow-node-body&quot;&gt;${esc(facet.description)}&lt;/div&gt;` : &#39;&#39;}
+          &lt;span class=&quot;flow-port flow-port-out&quot; data-port=&quot;facet-out&quot; data-facet-id=&quot;${esc(facet.id)}&quot; title=&quot;Drag to a section&#39;s left port to add coverage&quot;&gt;&lt;/span&gt;
+        &lt;/article&gt;`;
+    }).join(&#39;&#39;);
+
+    const sectionsHtml = sections.map((section) =&gt; {
+      const rationale = (section.rationale || &#39;&#39;).trim();
+      const rationaleHtml = rationale
+        ? `&lt;div class=&quot;flow-rationale&quot;&gt;${esc(rationale)}&lt;/div&gt;`
+        : `&lt;div class=&quot;flow-rationale flow-rationale-empty&quot;&gt;\u2014 no rationale declared yet \u2014&lt;/div&gt;`;
+      const cards = Array.isArray(section.data) ? section.data : [];
+      const chips = cards.filter((c) =&gt; c &amp;&amp; c.id).slice(0, 8).map((c) =&gt; `&lt;span class=&quot;flow-card-chip&quot;&gt;${esc(c.id)}&lt;/span&gt;`).join(&#39;&#39;);
+      const overflow = cards.filter((c) =&gt; c &amp;&amp; c.id).length - 8;
+      return `
+        &lt;article class=&quot;flow-node&quot; data-flow-kind=&quot;section&quot; data-flow-id=&quot;${esc(section.id)}&quot;${positionStyle(section)}&gt;
+          &lt;button type=&quot;button&quot; class=&quot;flow-remove&quot; data-flow-remove=&quot;section&quot; data-flow-id=&quot;${esc(section.id)}&quot; title=&quot;Remove section&quot;&gt;\u00d7&lt;/button&gt;
+          &lt;div class=&quot;flow-node-header&quot;&gt;
+            &lt;h5&gt;${esc(section.title || section.id)}&lt;/h5&gt;
+            &lt;span class=&quot;flow-badge flow-badge-ct&quot;&gt;${esc(section.convergenceType || &#39;&#39;)}&lt;/span&gt;
+          &lt;/div&gt;
+          &lt;div class=&quot;flow-node-id&quot;&gt;${esc(section.id)}&lt;/div&gt;
+          ${chips ? `&lt;div class=&quot;flow-card-chips&quot;&gt;${chips}${overflow &gt; 0 ? `&lt;span class=&quot;flow-card-chip&quot;&gt;+${overflow}&lt;/span&gt;` : &#39;&#39;}&lt;/div&gt;` : &#39;&#39;}
+          ${rationaleHtml}
+          &lt;span class=&quot;flow-port flow-port-in-left&quot; data-port=&quot;section-in&quot; data-section-id=&quot;${esc(section.id)}&quot; title=&quot;Coverage in-port&quot;&gt;&lt;/span&gt;
+          &lt;span class=&quot;flow-port flow-port-in-right&quot; data-port=&quot;section-inv-in&quot; data-section-id=&quot;${esc(section.id)}&quot; title=&quot;Invariant applies-to in-port&quot;&gt;&lt;/span&gt;
+        &lt;/article&gt;`;
+    }).join(&#39;&#39;);
+
+    const invariantsHtml = invariants.map((inv) =&gt; {
+      const applies = Array.isArray(inv.appliesTo) ? inv.appliesTo : [];
+      const docWide = applies.includes(&#39;*&#39;);
+      const docWideTitle = docWide
+        ? &#39;Doc-wide — click to scope to individual sections&#39;
+        : &#39;Click to make doc-wide (appliesTo: [&quot;*&quot;]); removes any section-specific entries&#39;;
+      return `
+        &lt;article class=&quot;flow-node flow-invariant&quot; data-flow-kind=&quot;invariant&quot; data-flow-id=&quot;${esc(inv.id)}&quot;${positionStyle(inv)}&gt;
+          &lt;button type=&quot;button&quot; class=&quot;flow-remove&quot; data-flow-remove=&quot;invariant&quot; data-flow-id=&quot;${esc(inv.id)}&quot; title=&quot;Remove invariant&quot;&gt;\u00d7&lt;/button&gt;
+          &lt;div class=&quot;flow-node-header&quot;&gt;
+            &lt;h5&gt;${esc(inv.name || inv.id)}&lt;/h5&gt;
+            &lt;button type=&quot;button&quot; class=&quot;flow-badge flow-badge-docwide${docWide ? &#39; flow-badge-docwide-active&#39; : &#39;&#39;}&quot; data-flow-docwide=&quot;${esc(inv.id)}&quot; title=&quot;${esc(docWideTitle)}&quot;&gt;Doc-wide&lt;/button&gt;
+          &lt;/div&gt;
+          &lt;div class=&quot;flow-node-id&quot;&gt;${esc(inv.id)}&lt;/div&gt;
+          ${inv.statement ? `&lt;div class=&quot;flow-invariant-statement&quot;&gt;${esc(inv.statement)}&lt;/div&gt;` : &#39;&#39;}
+          &lt;span class=&quot;flow-port flow-port-inv-out&quot; data-port=&quot;inv-out&quot; data-invariant-id=&quot;${esc(inv.id)}&quot; title=&quot;Drag to a section&#39;s right port to govern it&quot;&gt;&lt;/span&gt;
+        &lt;/article&gt;`;
+    }).join(&#39;&#39;);
+
+    return `
+      &lt;div class=&quot;flow-view&quot; id=&quot;flow-view&quot;&gt;
+        &lt;div class=&quot;flow-banner&quot; id=&quot;flow-banner&quot; data-state=&quot;checking&quot;&gt;
+          &lt;div class=&quot;flow-banner-body&quot;&gt;&lt;strong id=&quot;flow-banner-title&quot;&gt;${esc(t(&#39;flowMetaChecking&#39;))}&lt;/strong&gt; &lt;span id=&quot;flow-banner-message&quot;&gt;${esc(t(&#39;flowMetaCheckingBody&#39;))}&lt;/span&gt;&lt;/div&gt;
+          &lt;div class=&quot;flow-banner-actions&quot;&gt;
+            &lt;button type=&quot;button&quot; class=&quot;flow-banner-btn&quot; data-flow-stamp&gt;${esc(t(&#39;flowStampNow&#39;))}&lt;/button&gt;
+            &lt;button type=&quot;button&quot; class=&quot;flow-banner-btn flow-banner-btn-primary&quot; data-flow-crystallize&gt;${esc(t(&#39;flowCrystallize&#39;))}&lt;/button&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class=&quot;flow-stats&quot;&gt;${statsHtml}&lt;/div&gt;
+        &lt;div class=&quot;flow-canvas-wrap&quot; id=&quot;flow-canvas-wrap&quot;&gt;
+          &lt;div class=&quot;flow-canvas&quot; id=&quot;flow-canvas&quot;&gt;
+            &lt;svg class=&quot;flow-wires&quot; id=&quot;flow-wires&quot; aria-hidden=&quot;true&quot;&gt;
+              &lt;defs&gt;
+                &lt;marker id=&quot;flow-arrow-inv&quot; viewBox=&quot;0 0 10 10&quot; refX=&quot;9&quot; refY=&quot;5&quot; markerWidth=&quot;6&quot; markerHeight=&quot;6&quot; orient=&quot;auto-start-reverse&quot;&gt;
+                  &lt;path d=&quot;M 0 0 L 10 5 L 0 10 z&quot; fill=&quot;#d97706&quot;/&gt;
+                &lt;/marker&gt;
+              &lt;/defs&gt;
+            &lt;/svg&gt;
+            &lt;div class=&quot;flow-col flow-col-facets&quot;&gt;
+              &lt;h4&gt;${esc(t(&#39;flowColFacets&#39;))}&lt;span class=&quot;flow-col-count&quot;&gt;${facets.length}&lt;/span&gt;&lt;/h4&gt;
+              &lt;div class=&quot;flow-nodes&quot;&gt;${facetsHtml}&lt;/div&gt;
+            &lt;/div&gt;
+            &lt;div class=&quot;flow-col flow-col-sections&quot;&gt;
+              &lt;h4&gt;${esc(t(&#39;flowColSections&#39;))}&lt;span class=&quot;flow-col-count&quot;&gt;${sections.length}&lt;/span&gt;&lt;/h4&gt;
+              &lt;div class=&quot;flow-nodes&quot;&gt;${sectionsHtml}&lt;/div&gt;
+            &lt;/div&gt;
+            &lt;div class=&quot;flow-col flow-col-invariants&quot;&gt;
+              &lt;h4&gt;${esc(t(&#39;flowColInvariants&#39;))}&lt;span class=&quot;flow-col-count&quot;&gt;${invariants.length}&lt;/span&gt;&lt;/h4&gt;
+              &lt;div class=&quot;flow-nodes&quot;&gt;${invariantsHtml}&lt;/div&gt;
+            &lt;/div&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;`;
+  }
+
+  let flowDragState = null;
+
+  function drawFlowWires(doc) {
+    const wrap = document.getElementById(&#39;flow-canvas-wrap&#39;);
+    const wires = document.getElementById(&#39;flow-wires&#39;);
+    const canvas = document.getElementById(&#39;flow-canvas&#39;);
+    if (!wrap || !wires || !canvas) return;
+
+    const coverage = Array.isArray(doc.coverage) ? doc.coverage : [];
+    const invariants = Array.isArray(doc.invariants) ? doc.invariants : [];
+    const sections = Array.isArray(doc.sections) ? doc.sections : [];
+    const knownSectionIds = new Set(sections.map((s) =&gt; s.id));
+
+    const canvasRect = canvas.getBoundingClientRect();
+    wires.setAttribute(&#39;width&#39;,  String(canvasRect.width));
+    wires.setAttribute(&#39;height&#39;, String(canvasRect.height));
+
+    const svgX = (rect) =&gt; rect.left + rect.width / 2 - canvasRect.left;
+    const svgY = (rect) =&gt; rect.top + rect.height / 2 - canvasRect.top;
+    const cssEscape = (s) =&gt; String(s).replace(/[^a-zA-Z0-9_-]/g, (ch) =&gt; `\\${ch}`);
+    const bezier = (x1, y1, x2, y2) =&gt; {
+      const mid = (x1 + x2) / 2;
+      return `M ${x1} ${y1} C ${mid} ${y1}, ${mid} ${y2}, ${x2} ${y2}`;
+    };
+
+    const paths = [];
+
+    // Coverage wires
+    coverage.forEach((edge, idx) =&gt; {
+      const from = canvas.querySelector(`[data-port=&quot;facet-out&quot;][data-facet-id=&quot;${cssEscape(edge.facetId)}&quot;]`);
+      if (!from) return;
+      const drift = !knownSectionIds.has(edge.sectionId);
+      let toX, toY;
+      if (!drift) {
+        const sectionEl = canvas.querySelector(`[data-flow-kind=&quot;section&quot;][data-flow-id=&quot;${cssEscape(edge.sectionId)}&quot;]`);
+        const toPort = sectionEl?.querySelector(&#39;[data-port=&quot;section-in&quot;]&#39;);
+        if (!toPort) return;
+        const r = toPort.getBoundingClientRect();
+        toX = svgX(r); toY = svgY(r);
+      } else {
+        const fr = from.getBoundingClientRect();
+        toX = canvasRect.width * 0.62;
+        toY = svgY(fr);
+      }
+      const fr = from.getBoundingClientRect();
+      const d = bezier(svgX(fr), svgY(fr), toX, toY);
+      paths.push(`&lt;path class=&quot;flow-wire-hit&quot; d=&quot;${d}&quot; data-flow-edge=&quot;coverage&quot; data-flow-edge-index=&quot;${idx}&quot;&gt;&lt;/path&gt;`);
+      paths.push(`&lt;path class=&quot;flow-wire-coverage ${drift ? &#39;flow-wire-drift&#39; : &#39;&#39;}&quot; d=&quot;${d}&quot;/&gt;`);
+    });
+
+    // Invariant arrows — one path per (invariantIdx, appliesToIdx) pair
+    invariants.forEach((inv, invIdx) =&gt; {
+      const from = canvas.querySelector(`[data-port=&quot;inv-out&quot;][data-invariant-id=&quot;${cssEscape(inv.id)}&quot;]`);
+      if (!from) return;
+      const applies = Array.isArray(inv.appliesTo) ? inv.appliesTo : [];
+      const fr = from.getBoundingClientRect();
+      const fromX = svgX(fr), fromY = svgY(fr);
+      applies.forEach((target, targetIdx) =&gt; {
+        let toX, toY;
+        if (target === &#39;*&#39;) {
+          const sectionsCol = canvas.querySelector(&#39;.flow-col-sections&#39;)?.getBoundingClientRect();
+          toX = sectionsCol ? sectionsCol.right - canvasRect.left + 6 : canvasRect.width * 0.62;
+          toY = sectionsCol ? sectionsCol.top - canvasRect.top - 10 : fromY;
+        } else {
+          const sectionEl = canvas.querySelector(`[data-flow-kind=&quot;section&quot;][data-flow-id=&quot;${cssEscape(target)}&quot;]`);
+          const toPort = sectionEl?.querySelector(&#39;[data-port=&quot;section-inv-in&quot;]&#39;);
+          if (!toPort) return;
+          const r = toPort.getBoundingClientRect();
+          toX = svgX(r); toY = svgY(r);
+        }
+        const d = bezier(fromX, fromY, toX, toY);
+        paths.push(`&lt;path class=&quot;flow-wire-hit&quot; d=&quot;${d}&quot; data-flow-edge=&quot;invariant&quot; data-flow-inv-index=&quot;${invIdx}&quot; data-flow-target-index=&quot;${targetIdx}&quot;&gt;&lt;/path&gt;`);
+        paths.push(`&lt;path class=&quot;flow-wire-invariant&quot; d=&quot;${d}&quot; marker-end=&quot;url(#flow-arrow-inv)&quot;/&gt;`);
+      });
+    });
+
+    // Drag preview
+    if (flowDragState) {
+      const portSel = flowDragState.kind === &#39;invariant&#39;
+        ? `[data-port=&quot;inv-out&quot;][data-invariant-id=&quot;${cssEscape(flowDragState.fromId)}&quot;]`
+        : `[data-port=&quot;facet-out&quot;][data-facet-id=&quot;${cssEscape(flowDragState.fromId)}&quot;]`;
+      const from = canvas.querySelector(portSel);
+      if (from) {
+        const fr = from.getBoundingClientRect();
+        const fromX = svgX(fr), fromY = svgY(fr);
+        const toX = flowDragState.mouseX - canvasRect.left;
+        const toY = flowDragState.mouseY - canvasRect.top;
+        const d = bezier(fromX, fromY, toX, toY);
+        const cls = flowDragState.kind === &#39;invariant&#39;
+          ? &#39;flow-wire-invariant flow-wire-preview&#39;
+          : &#39;flow-wire-coverage flow-wire-preview&#39;;
+        const marker = flowDragState.kind === &#39;invariant&#39; ? &#39; marker-end=&quot;url(#flow-arrow-inv)&quot;&#39; : &#39;&#39;;
+        paths.push(`&lt;path class=&quot;${cls}&quot; d=&quot;${d}&quot;${marker}/&gt;`);
+      }
+    }
+
+    const defs = wires.querySelector(&#39;defs&#39;);
+    wires.innerHTML = (defs ? defs.outerHTML : &#39;&#39;) + paths.join(&#39;&#39;);
   }
 
   function renderJsonPreview(json) {
@@ -10375,12 +11320,45 @@ open docs/living-doc-compositor.html&lt;/pre&gt;
           &lt;div class=&quot;guide-layer-body&quot;&gt;
             &lt;p&gt;${esc(t(&#39;guideLayer4Body1&#39;))}&lt;/p&gt;
             &lt;p&gt;${esc(t(&#39;guideLayer4Body2&#39;))}&lt;/p&gt;
+            &lt;p&gt;&lt;em&gt;${esc(t(&#39;guideLayer4FlowIntro&#39;))}&lt;/em&gt;&lt;/p&gt;
 
             &lt;div class=&quot;guide-card-stack&quot;&gt;
-              ${infoCard(t(&#39;guideLayer4FacetsTitle&#39;), t(&#39;guideLayer4FacetsBody&#39;))}
-              ${infoCard(t(&#39;guideLayer4CoverageTitle&#39;), t(&#39;guideLayer4CoverageBody&#39;))}
-              ${infoCard(t(&#39;guideLayer4InvariantsTitle&#39;), t(&#39;guideLayer4InvariantsBody&#39;))}
-              ${infoCard(t(&#39;guideLayer4FingerprintTitle&#39;), t(&#39;guideLayer4FingerprintBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4FacetsTitle&#39;), t(&#39;guideLayer4FacetsBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowFacets&#39;))}&lt;/p&gt;`)}
+              ${infoCard(t(&#39;guideLayer4CoverageTitle&#39;), t(&#39;guideLayer4CoverageBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowCoverage&#39;))}&lt;/p&gt;`)}
+              ${infoCard(t(&#39;guideLayer4InvariantsTitle&#39;), t(&#39;guideLayer4InvariantsBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowInvariants&#39;))}&lt;/p&gt;`)}
+              ${infoCard(t(&#39;guideLayer4FingerprintTitle&#39;), t(&#39;guideLayer4FingerprintBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowFingerprint&#39;))}&lt;/p&gt;`)}
+            &lt;/div&gt;
+
+            &lt;h3&gt;${esc(t(&#39;guideLayer4ReadingTitle&#39;))}&lt;/h3&gt;
+            &lt;p style=&quot;color:var(--muted)&quot;&gt;${esc(t(&#39;guideLayer4ReadingBody&#39;))}&lt;/p&gt;
+            &lt;div class=&quot;guide-card-stack&quot;&gt;
+              ${infoCard(&#39;Columns&#39;, t(&#39;guideLayer4ReadingColumns&#39;))}
+              ${infoCard(&#39;Wires&#39;, t(&#39;guideLayer4ReadingWires&#39;))}
+              ${infoCard(&#39;States&#39;, t(&#39;guideLayer4ReadingStates&#39;))}
+              ${infoCard(&#39;Stats bar&#39;, t(&#39;guideLayer4ReadingStats&#39;))}
+              ${infoCard(&#39;Rationale&#39;, t(&#39;guideLayer4ReadingRationale&#39;))}
+            &lt;/div&gt;
+
+            &lt;h3&gt;${esc(t(&#39;guideLayer4DeepTitle&#39;))}&lt;/h3&gt;
+            &lt;p style=&quot;color:var(--muted)&quot;&gt;${esc(t(&#39;guideLayer4DeepIntro&#39;))}&lt;/p&gt;
+            &lt;div class=&quot;guide-card-stack&quot;&gt;
+              ${infoCard(t(&#39;guideLayer4DeepHashTitle&#39;), t(&#39;guideLayer4DeepHashBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4DeepMomentTitle&#39;), t(&#39;guideLayer4DeepMomentBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4DeepStatesTitle&#39;), t(&#39;guideLayer4DeepStatesBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4DeepRitualsTitle&#39;), t(&#39;guideLayer4DeepRitualsBody&#39;))}
+            &lt;/div&gt;
+            &lt;div class=&quot;guide-accent-callout&quot; style=&quot;margin-top:10px&quot;&gt;
+              &lt;strong&gt;${esc(t(&#39;guideLayer4DeepBridgeTitle&#39;))}&lt;/strong&gt;&lt;br /&gt;
+              &lt;span style=&quot;color:var(--muted);font-size:13.5px&quot;&gt;${esc(t(&#39;guideLayer4DeepBridgeBody&#39;))}&lt;/span&gt;
+            &lt;/div&gt;
+
+            &lt;h3&gt;${esc(t(&#39;guideLayer4EditingTitle&#39;))}&lt;/h3&gt;
+            &lt;p style=&quot;color:var(--muted)&quot;&gt;${esc(t(&#39;guideLayer4EditingBody&#39;))}&lt;/p&gt;
+            &lt;div class=&quot;guide-card-stack&quot;&gt;
+              ${stepCard(1, &#39;Drag a port&#39;, esc(t(&#39;guideLayer4EditingDrag&#39;)))}
+              ${stepCard(2, &#39;Click a wire or chip&#39;, esc(t(&#39;guideLayer4EditingClick&#39;)))}
+              ${stepCard(3, &#39;Delete a node&#39;, esc(t(&#39;guideLayer4EditingRemove&#39;)))}
+              ${stepCard(4, &#39;Reposition and reset&#39;, esc(t(&#39;guideLayer4EditingPosition&#39;)))}
             &lt;/div&gt;
 
             &lt;div class=&quot;guide-accent-callout&quot;&gt;
@@ -12097,7 +13075,7 @@ open docs/living-doc-compositor.html&lt;/pre&gt;
 
     <div class="snapshot-item">
       <span class="snapshot-label">Generated</span>
-      <span class="snapshot-value"><time datetime="2026-04-17T04:28:52.307Z" title="2026-04-17T04:28:52.307Z" data-snapshot-anchor="generated-at" id="snapshot-generated-at">2026-04-17T04:28:52.307Z</time></span>
+      <span class="snapshot-value"><time datetime="2026-04-17T13:00:54.384Z" title="2026-04-17T13:00:54.384Z" data-snapshot-anchor="generated-at" id="snapshot-generated-at">2026-04-17T13:00:54.384Z</time></span>
     </div>
 
     <div class="snapshot-item">
@@ -12245,7 +13223,7 @@ open docs/living-doc-compositor.html&lt;/pre&gt;
     </section>
 
 
-          <p class="footnote" style="margin-top:40px">Living Doc Compositor v0.1.0-339dfc8 (2026-04-17)</p>
+          <p class="footnote" style="margin-top:40px">Living Doc Compositor v0.1.0-0103671 (2026-04-17)</p>
         </div>
 
     <section id="board-view" class="view-panel board-view" data-view-panel="board" hidden>

--- a/docs/mobile-companion-workstream.html
+++ b/docs/mobile-companion-workstream.html
@@ -1967,7 +1967,208 @@
     background: var(--card); font-size: 12.5px; font-weight: 600; color: var(--muted);
   }
   .preview-tab.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+  .flow-placeholder {
+    margin: 24px; padding: 32px 36px; border-radius: 14px;
+    background: var(--card); border: 1px dashed var(--line);
+    max-width: 720px;
+  }
+  .flow-placeholder-eyebrow {
+    display: inline-block; padding: 3px 10px; border-radius: 999px;
+    background: color-mix(in srgb, var(--accent) 12%, var(--card));
+    color: var(--accent); font-size: 11px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 12px;
+  }
+  .flow-placeholder h3 { margin: 0 0 8px; font-size: 18px; letter-spacing: -0.01em; }
+  .flow-placeholder p { margin: 0 0 16px; color: var(--muted); line-height: 1.6; font-size: 13.5px; }
+  .flow-placeholder-summary {
+    padding: 10px 14px; border-radius: 8px;
+    background: color-mix(in srgb, var(--accent) 6%, var(--card));
+    border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--line));
+    font-size: 12.5px; color: var(--ink);
+  }
+  .flow-placeholder-summary-empty {
+    background: color-mix(in srgb, #f59e0b 10%, var(--card));
+    border-color: color-mix(in srgb, #f59e0b 30%, var(--line));
+    color: #92400e;
+  }
+  .flow-view { display: flex; flex-direction: column; min-height: 100%; }
+  .flow-stats {
+    display: flex; gap: 6px; padding: 10px 16px;
+    border-bottom: 1px solid var(--line); background: var(--card);
+    flex-wrap: wrap; position: sticky; top: 0; z-index: 2;
+  }
+  .flow-stat {
+    display: inline-flex; gap: 6px; padding: 4px 10px; border-radius: 999px;
+    background: var(--bg); border: 1px solid var(--line); font-size: 12px;
+  }
+  .flow-stat strong { color: var(--ink); font-weight: 700; }
+  .flow-stat-warn { background: #fffbeb; color: #92400e; border-color: #fde68a; }
+  .flow-stat-bad { background: #fef2f2; color: #991b1b; border-color: #fecaca; }
+  .flow-canvas-wrap {
+    position: relative; flex: 1; overflow: auto; background: var(--bg);
+    min-height: 420px;
+  }
+  .flow-canvas {
+    position: relative; display: grid;
+    grid-template-columns: 260px 260px 260px;
+    gap: 72px; padding: 24px 28px 48px;
+    min-width: 924px;
+    justify-content: start;
+  }
+  .flow-col h4 {
+    margin: 0 0 10px; font-size: 11px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted);
+  }
+  .flow-col h4 .flow-col-count {
+    margin-left: 6px; padding: 1px 8px; border-radius: 999px;
+    background: var(--card); border: 1px solid var(--line);
+    color: var(--muted); font-size: 10px; font-weight: 700;
+  }
+  .flow-nodes { display: flex; flex-direction: column; gap: 10px; }
+  .flow-node {
+    position: relative; padding: 10px 12px 10px 14px;
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  }
+  .flow-node-header {
+    display: flex; gap: 6px; align-items: baseline; flex-wrap: wrap;
+  }
+  .flow-node-header h5 { margin: 0; font-size: 13px; font-weight: 700; }
+  .flow-node-id {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 10.5px; color: var(--muted);
+  }
+  .flow-node-body { margin-top: 4px; font-size: 12px; color: var(--muted); line-height: 1.5; }
+  .flow-badge {
+    display: inline-flex; padding: 1px 8px; border-radius: 999px;
+    font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flow-badge-ct { background: #ecfeff; color: #155e75; margin-left: auto; }
+  .flow-badge-orphan { background: #fef2f2; color: #991b1b; }
+  .flow-badge-docwide { background: #fef3c7; color: #92400e; margin-left: auto; cursor: pointer; border: 1px solid #fde68a; transition: background 0.15s, border-color 0.15s; }
+  .flow-badge-docwide:hover { background: #fde68a; border-color: #f59e0b; }
+  .flow-badge-docwide.flow-badge-docwide-active { background: #d97706; color: #fff; border-color: #d97706; }
+  .flow-badge-docwide.flow-badge-docwide-active:hover { background: #b45309; border-color: #b45309; }
+  .flow-node-orphan {
+    background: color-mix(in srgb, #fef2f2 40%, var(--card));
+    border-color: #fecaca;
+  }
+  .flow-card-chips { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 6px; }
+  .flow-card-chip {
+    display: inline-flex; padding: 1px 7px; border-radius: 5px;
+    background: var(--bg); border: 1px solid var(--line);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 10px; color: var(--muted);
+  }
+  .flow-rationale {
+    margin-top: 8px; padding: 6px 9px; border-radius: 7px;
+    background: var(--bg); border: 1px dashed var(--line);
+    font-size: 11.5px; font-style: italic; color: var(--muted); line-height: 1.5;
+  }
+  .flow-rationale-empty {
+    color: color-mix(in srgb, var(--muted) 55%, var(--card));
+    border-style: dotted;
+  }
+  .flow-invariant {
+    background: color-mix(in srgb, #fffbeb 45%, var(--card));
+    border-color: #fde68a;
+  }
+  .flow-invariant-statement {
+    margin-top: 5px; font-size: 11.5px; color: #78350f; line-height: 1.5;
+  }
+  .flow-port {
+    position: absolute; top: 50%; transform: translateY(-50%);
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--card); border: 2px solid #94a3b8; z-index: 3;
+  }
+  .flow-port-out { right: -7px; }
+  .flow-port-in-left { left: -7px; }
+  .flow-port-in-right { right: -7px; border-color: #d97706; }
+  .flow-port-inv-out { left: -7px; border-color: #d97706; }
+  .flow-wires {
+    position: absolute; inset: 0; width: 100%; height: 100%;
+    pointer-events: none; z-index: 1;
+  }
+  .flow-wires path { fill: none; }
+  .flow-wires path.flow-wire-coverage, .flow-wires path.flow-wire-invariant { pointer-events: none; }
+  .flow-wire-coverage { stroke: #94a3b8; stroke-width: 2; }
+  .flow-wire-coverage.flow-wire-drift { stroke: #b91c1c; stroke-dasharray: 4 4; }
+  .flow-wire-invariant { stroke: #d97706; stroke-width: 2; }
+  .flow-wire-hit { stroke: transparent; stroke-width: 16; pointer-events: stroke; cursor: pointer; }
+  .flow-wire-preview { stroke-dasharray: 6 4; opacity: 0.8; pointer-events: none; }
+  .flow-port { cursor: crosshair; transition: transform 0.12s, background 0.15s, border-color 0.15s; }
+  .flow-port:hover { transform: translateY(-50%) scale(1.35); background: var(--accent); border-color: var(--accent); }
+  .flow-port-in-right:hover, .flow-port-inv-out:hover { background: #d97706; border-color: #d97706; }
+  .flow-port.flow-port-dragging { background: var(--accent); border-color: var(--accent); }
+  .flow-port.flow-port-dragging-inv { background: #d97706; border-color: #d97706; }
+  .flow-remove {
+    position: absolute; top: 6px; right: 6px;
+    width: 20px; height: 20px; border-radius: 50%;
+    border: 1px solid var(--line); background: var(--card);
+    color: var(--muted); font-size: 13px; line-height: 1;
+    cursor: pointer; opacity: 0; transition: opacity 0.15s;
+    display: inline-flex; align-items: center; justify-content: center;
+    padding: 0;
+  }
+  .flow-node:hover .flow-remove { opacity: 1; }
+  .flow-remove:hover { background: #fef2f2; color: #991b1b; border-color: #991b1b; }
+  .flow-rationale { cursor: pointer; transition: border-color 0.15s, color 0.15s; }
+  .flow-rationale:hover { border-color: var(--accent); color: var(--ink); }
+  .flow-banner {
+    display: none; gap: 14px; align-items: center; flex-wrap: wrap;
+    padding: 12px 16px; border-bottom: 1px solid var(--line);
+    background: var(--card); font-size: 13px; line-height: 1.5;
+  }
+  .flow-banner[data-state=&quot;missing&quot;] {
+    display: flex; background: var(--neutral-bg); color: var(--neutral-ink);
+    border-bottom-color: var(--line);
+  }
+  .flow-banner[data-state=&quot;stale&quot;] {
+    display: flex;
+    background: color-mix(in srgb, #fffbeb 65%, var(--card));
+    color: #92400e;
+    border-bottom-color: #fde68a;
+  }
+  .flow-banner strong { font-weight: 700; }
+  .flow-banner-body { flex: 1; min-width: 200px; }
+  .flow-banner-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+  .flow-banner-btn {
+    padding: 5px 12px; font: inherit; font-size: 12px; font-weight: 600;
+    border: 1px solid var(--line); background: var(--card); border-radius: 7px;
+    color: var(--ink); cursor: pointer;
+  }
+  .flow-banner-btn:hover { border-color: var(--accent); color: var(--accent); }
+  .flow-banner-btn-primary { background: #d97706; color: #fff; border-color: #d97706; }
+  .flow-banner-btn-primary:hover { background: #b45309; border-color: #b45309; color: #fff; }
+  .flow-canvas-wrap.flow-stale .flow-wire-coverage,
+  .flow-canvas-wrap.flow-stale .flow-wire-invariant {
+    opacity: 0.4; filter: saturate(0.6);
+  }
+  .flow-canvas-wrap.flow-stale .flow-wire-coverage.flow-wire-drift { opacity: 0.5; }
+  .flow-node { cursor: grab; }
+  .flow-node:active { cursor: grabbing; }
+  .flow-node .flow-port,
+  .flow-node .flow-remove,
+  .flow-node .flow-badge-docwide,
+  .flow-node .flow-rationale { cursor: pointer; }
+  .flow-node[data-flow-positioned=&quot;true&quot;] { position: absolute; z-index: 2; width: 260px; }
+  .flow-node.flow-node-dragging { opacity: 0.85; box-shadow: 0 4px 14px rgba(0,0,0,0.12); cursor: grabbing; z-index: 3; user-select: none; }
+  .flow-node.flow-node-dragging * { user-select: none; }
+  .flow-node .flow-node-header h5 { user-select: none; }
+  .flow-reset-layout-btn {
+    margin-left: auto; padding: 4px 10px; font: inherit; font-size: 12px; font-weight: 600;
+    border: 1px solid var(--line); background: var(--card); border-radius: 7px;
+    color: var(--muted); cursor: pointer;
+  }
+  .flow-reset-layout-btn:hover { border-color: var(--accent); color: var(--accent); }
+  .flow-empty {
+    margin: 24px; padding: 32px 36px; border-radius: 14px;
+    background: var(--card); border: 1px dashed var(--line);
+    max-width: 720px; color: var(--muted); font-size: 13.5px; line-height: 1.6;
+  }
+  .flow-empty strong { color: var(--ink); display: block; margin-bottom: 8px; font-size: 15px; }
   .preview-content { padding: 24px; scroll-behavior: smooth; }
+  .preview-content.preview-content-flow { padding: 0; display: flex; flex-direction: column; }
   .preview-iframe { width: 100%; border: none; border-radius: var(--radius); background: #fff; min-height: calc(100vh - 80px); }
   .doc-editor-card {
     margin-bottom: 18px; padding: 20px; border-radius: 14px;
@@ -2824,7 +3025,26 @@
       &quot;preview&quot;: &quot;Preview&quot;,
       &quot;visual&quot;: &quot;Visual&quot;,
       &quot;board&quot;: &quot;Board&quot;,
+      &quot;flow&quot;: &quot;Flow&quot;,
       &quot;json&quot;: &quot;JSON&quot;,
+      &quot;flowEmptyTitle&quot;: &quot;Governance canvas&quot;,
+      &quot;flowEmptyBody&quot;: &quot;The Flow view renders the doc&#39;s governance layer — objective facets, coverage edges, invariants, and rationale — as a canvas. Canvas rendering lands in #47. Tab is in place; data-flow wiring follows.&quot;,
+      &quot;flowMissingGovernance&quot;: &quot;This doc has no governance data yet. Run /crystallize on the JSON to populate objectiveFacets, coverage, and invariants.&quot;,
+      &quot;flowColFacets&quot;: &quot;Objective facets&quot;,
+      &quot;flowColSections&quot;: &quot;Sections&quot;,
+      &quot;flowColInvariants&quot;: &quot;Invariants&quot;,
+      &quot;flowMetaChecking&quot;: &quot;Checking meta freshness…&quot;,
+      &quot;flowMetaCheckingBody&quot;: &quot;Computing the current section fingerprint.&quot;,
+      &quot;flowMetaMissingTitle&quot;: &quot;Meta not yet stamped.&quot;,
+      &quot;flowMetaMissingBody&quot;: &quot;Run /crystallize to seed objectiveFacets, coverage, invariants, and a metaFingerprint so drift becomes detectable.&quot;,
+      &quot;flowMetaStaleTitle&quot;: &quot;Meta is stale.&quot;,
+      &quot;flowMetaStaleBody&quot;: &quot;Sections have changed since the meta was derived. Coverage edges may point at the wrong cards. Run /crystallize --refresh or stamp a new fingerprint.&quot;,
+      &quot;flowStampNow&quot;: &quot;Stamp fingerprint now&quot;,
+      &quot;flowStamping&quot;: &quot;Stamping…&quot;,
+      &quot;flowStamped&quot;: &quot;Stamped&quot;,
+      &quot;flowCrystallize&quot;: &quot;Copy /crystallize prompt&quot;,
+      &quot;flowCrystallizeCopied&quot;: &quot;Copied&quot;,
+      &quot;flowResetLayout&quot;: &quot;Reset layout&quot;,
       &quot;templates&quot;: &quot;Templates&quot;,
       &quot;templatesHint&quot;: &quot;Browse starter and advanced living doc templates&quot;,
       &quot;templatesIntro&quot;: &quot;Start with a simple starter template or jump straight into a fuller advanced shape.&quot;,
@@ -2960,7 +3180,37 @@
       &quot;guideLayer4FingerprintTitle&quot;: &quot;Fingerprint and freshness&quot;,
       &quot;guideLayer4FingerprintBody&quot;: &quot;A sha256 of the section structure at crystallization time. Renders as a banner when the sections have moved but the meta has not — stale coverage is worse than no coverage, so drift becomes loud.&quot;,
       &quot;guideLayer4CrystallizeTitle&quot;: &quot;Second-pass refinement, not an authoring gate&quot;,
-      &quot;guideLayer4CrystallizeBody&quot;: &quot;Don&#39;t crystallize early iteration — facets haven&#39;t settled. Run `/crystallize &lt;doc&gt;` once the shape is stable; the skill proposes facets, coverage, invariants, and rationale from what the doc already contains. Re-run with `--refresh` on structural change.&quot;,
+      &quot;guideLayer4CrystallizeBody&quot;: &quot;Don&#39;t crystallize early iteration — facets haven&#39;t settled. Run `/crystallize &lt;doc&gt;` once the shape is stable; the skill proposes facets, coverage, invariants, and rationale from what the doc already contains. Re-run with `--refresh` on structural change. Open the Flow tab to watch the facets and coverage populate as the skill writes them.&quot;,
+      &quot;guideLayer4FlowIntro&quot;: &quot;The Flow tab in the compositor is the primary surface for governance. Open a crystallized doc, switch to Flow, and the layer becomes a canvas: facets on the left, sections in the middle, invariants on the right, with typed wires between them.&quot;,
+      &quot;guideLayer4FlowFacets&quot;: &quot;In the Flow canvas: the left column. Orphan facets render as pink cards with an Orphan badge, so gaps in the coverage are visible at a glance. Drag a facet&#39;s right port to a section&#39;s left port to add a coverage edge.&quot;,
+      &quot;guideLayer4FlowCoverage&quot;: &quot;In the Flow canvas: gray bezier wires from each facet&#39;s right port to the section&#39;s left port. Drift (the target section has been removed) renders as a dashed red wire trailing off toward the sections column. Click a wire to remove it.&quot;,
+      &quot;guideLayer4FlowInvariants&quot;: &quot;In the Flow canvas: the right column, amber arrows with arrowheads point at the sections they govern. Click the Doc-wide chip on an invariant to toggle `appliesTo: [\&quot;*\&quot;]`; the arrows collapse into one arrow pointing at a virtual anchor above the sections column. Drag to a specific section to rescope.&quot;,
+      &quot;guideLayer4FlowFingerprint&quot;: &quot;In the Flow canvas: an amber banner pins at the top when the fingerprint is stale. Coverage and invariant wires dim and desaturate so the stale state is unmistakable. The banner&#39;s Stamp button re-computes and stores the new fingerprint; the Crystallize button copies `/crystallize &lt;doc&gt; --refresh` to the clipboard.&quot;,
+      &quot;guideLayer4ReadingTitle&quot;: &quot;Reading the Flow canvas&quot;,
+      &quot;guideLayer4ReadingBody&quot;: &quot;Three columns, three roles. Two wire colors, two node states. One italicized footer per section.&quot;,
+      &quot;guideLayer4ReadingColumns&quot;: &quot;Columns · Objective facets (left) → sections (middle) → invariants (right). Each is a governance role expressed as a column.&quot;,
+      &quot;guideLayer4ReadingWires&quot;: &quot;Wires · Gray bezier = coverage (facet is carried by section). Amber bezier with arrowhead = invariant (rule governs section). Dashed variants signal drift or in-flight preview.&quot;,
+      &quot;guideLayer4ReadingStates&quot;: &quot;States · Pink facet card + Orphan badge = no coverage edges. Dashed red wire = drifted (points at a missing section). Dimmed + desaturated wires = metaFingerprint is stale.&quot;,
+      &quot;guideLayer4ReadingStats&quot;: &quot;Stats bar · Pinned at the top: facet / section / coverage / invariant counts, rationale declared vs total, and loud pills for orphan or drift counts when either is non-zero.&quot;,
+      &quot;guideLayer4ReadingRationale&quot;: &quot;Rationale · Italicized dashed card at the bottom of each section node. A dotted \&quot;no rationale declared yet\&quot; stub appears when the field is missing so authoring gaps stay visible.&quot;,
+      &quot;guideLayer4EditingTitle&quot;: &quot;Editing via the Flow canvas&quot;,
+      &quot;guideLayer4EditingBody&quot;: &quot;Every interaction writes to the same `docExtras` that `/crystallize` and the tabular editor use, so the canvas stays in sync with the other views.&quot;,
+      &quot;guideLayer4EditingDrag&quot;: &quot;Drag a port → create a wire. Facet out-port to section in-port adds coverage (picks an unused cardId from the section). Invariant out-port to section right-port adds that section to `appliesTo`, stripping any existing `\&quot;*\&quot;`.&quot;,
+      &quot;guideLayer4EditingClick&quot;: &quot;Click a wire → remove it. Click the Doc-wide chip on an invariant → toggle doc-wide scope. Click a section&#39;s rationale card → edit the sentence inline via prompt.&quot;,
+      &quot;guideLayer4EditingRemove&quot;: &quot;× on hover → delete a node. Facets cascade their coverage; sections intentionally leave coverage edges behind as drift (the visual signal stays visible); invariants are a clean delete.&quot;,
+      &quot;guideLayer4EditingPosition&quot;: &quot;Drag a node body → reposition on the canvas (`flowPosition` saves to the node). Double-click → return to column. Reset layout button in the stats bar → clear all custom positions.&quot;,
+      &quot;guideLayer4DeepTitle&quot;: &quot;Fingerprint, freshness, and the crystallization moment&quot;,
+      &quot;guideLayer4DeepIntro&quot;: &quot;The fingerprint is cheap to compute and load-bearing. Understanding what it hashes, when to stamp it, and what freshness means turns governance from a static label into a living contract.&quot;,
+      &quot;guideLayer4DeepHashTitle&quot;: &quot;What the fingerprint hashes&quot;,
+      &quot;guideLayer4DeepHashBody&quot;: &quot;A sha256 of each section&#39;s id, convergenceType, and ordered card ids. Stable under prose edits within cards; unstable when sections are added or removed, renamed, or restructured. The choice is deliberate — governance maps to structure, not to content.&quot;,
+      &quot;guideLayer4DeepMomentTitle&quot;: &quot;The crystallization moment&quot;,
+      &quot;guideLayer4DeepMomentBody&quot;: &quot;Think of it as a git commit on the doc&#39;s meaning. Before the stamp, the doc is in shape-discovery mode and governance would calcify bad decompositions. After the stamp, governance pins to an exact structural state. Crystallize when the shape is stable enough that a week of small edits won&#39;t reshape it.&quot;,
+      &quot;guideLayer4DeepStatesTitle&quot;: &quot;Three states, three postures&quot;,
+      &quot;guideLayer4DeepStatesBody&quot;: &quot;Missing — no fingerprint, nothing to check; agents fall back to prose re-derivation. Fresh — stored matches current; agents deterministically target the right cards via coverage edges. Stale — stored differs from current; wires dim and agents must fall back to prose, because coverage may now point at cards whose meaning has shifted.&quot;,
+      &quot;guideLayer4DeepRitualsTitle&quot;: &quot;Stamp vs refresh&quot;,
+      &quot;guideLayer4DeepRitualsBody&quot;: &quot;Stamp (from the Flow banner) — recompute the sha256 and store it. Preserves existing facets, coverage, invariants, and rationale. Use when the structural edit is semantic-neutral (renamed a section you just added, reshuffled a card id). Refresh via `/crystallize &lt;doc&gt; --refresh` — rerun the skill. Proposes updated facets and coverage for the new structure; preserves author-edited fields. Use when the change is genuinely new shape.&quot;,
+      &quot;guideLayer4DeepBridgeTitle&quot;: &quot;Why this bridges authoring and long-term coherence&quot;,
+      &quot;guideLayer4DeepBridgeBody&quot;: &quot;Without a fingerprint, \&quot;is this doc still coherent?\&quot; requires an LLM re-read and human judgment on every pass. With a fingerprint, it&#39;s a hash comparison. That collapse — from judgment to verification — is what turns a living doc from an opinionated structure into a testable substrate. Over time it enables empirical evaluation of which doc shapes actually perform well for human and agent readers alike.&quot;,
       &quot;guideLayer5Title&quot;: &quot;Extending the Vocabulary&quot;,
       &quot;guideLayer5Tagline&quot;: &quot;Creating a new convergence type when nothing fits.&quot;,
       &quot;guideLayer6Title&quot;: &quot;Working with Living Docs&quot;,
@@ -3095,7 +3345,26 @@
       &quot;preview&quot;: &quot;Voorbeeld&quot;,
       &quot;visual&quot;: &quot;Visueel&quot;,
       &quot;board&quot;: &quot;Bord&quot;,
+      &quot;flow&quot;: &quot;Flow&quot;,
       &quot;json&quot;: &quot;JSON&quot;,
+      &quot;flowEmptyTitle&quot;: &quot;Governance-canvas&quot;,
+      &quot;flowEmptyBody&quot;: &quot;De Flow-weergave rendert de governance-laag van het document — doelfacetten, coverage-edges, invarianten en rationale — als canvas. Canvasrendering landt in #47. Het tabblad staat; datastromen volgen.&quot;,
+      &quot;flowMissingGovernance&quot;: &quot;Dit document heeft nog geen governance-data. Draai /crystallize op de JSON om objectiveFacets, coverage en invariants te vullen.&quot;,
+      &quot;flowColFacets&quot;: &quot;Doelfacetten&quot;,
+      &quot;flowColSections&quot;: &quot;Secties&quot;,
+      &quot;flowColInvariants&quot;: &quot;Invarianten&quot;,
+      &quot;flowMetaChecking&quot;: &quot;Versheid van meta controleren…&quot;,
+      &quot;flowMetaCheckingBody&quot;: &quot;Huidige sectievingerafdruk berekenen.&quot;,
+      &quot;flowMetaMissingTitle&quot;: &quot;Meta nog niet gestempeld.&quot;,
+      &quot;flowMetaMissingBody&quot;: &quot;Draai /crystallize om objectiveFacets, coverage, invariants en een metaFingerprint te zaaien zodat drift detecteerbaar wordt.&quot;,
+      &quot;flowMetaStaleTitle&quot;: &quot;Meta is verouderd.&quot;,
+      &quot;flowMetaStaleBody&quot;: &quot;Secties zijn gewijzigd sinds de meta werd afgeleid. Coverage-edges kunnen naar verkeerde kaarten wijzen. Draai /crystallize --refresh of stempel een nieuwe vingerafdruk.&quot;,
+      &quot;flowStampNow&quot;: &quot;Vingerafdruk nu stempelen&quot;,
+      &quot;flowStamping&quot;: &quot;Stempelen…&quot;,
+      &quot;flowStamped&quot;: &quot;Gestempeld&quot;,
+      &quot;flowCrystallize&quot;: &quot;Kopieer /crystallize-prompt&quot;,
+      &quot;flowCrystallizeCopied&quot;: &quot;Gekopieerd&quot;,
+      &quot;flowResetLayout&quot;: &quot;Layout resetten&quot;,
       &quot;templates&quot;: &quot;Templates&quot;,
       &quot;templatesHint&quot;: &quot;Blader door starter- en geavanceerde living-doc-templates&quot;,
       &quot;templatesIntro&quot;: &quot;Begin met een eenvoudige starter-template of spring direct naar een uitgebreidere geavanceerde vorm.&quot;,
@@ -3402,7 +3671,37 @@
       &quot;guideLayer4FingerprintTitle&quot;: &quot;Vingerafdruk en versheid&quot;,
       &quot;guideLayer4FingerprintBody&quot;: &quot;Een sha256 van de sectiestructuur op het moment van uitkristalliseren. Toont een banner wanneer secties zijn verschoven maar de meta niet — verouderde coverage is erger dan geen coverage, dus drift wordt luid.&quot;,
       &quot;guideLayer4CrystallizeTitle&quot;: &quot;Tweede-pass verfijning, geen authoring-gate&quot;,
-      &quot;guideLayer4CrystallizeBody&quot;: &quot;Kristalliseer niet in vroege iteratie — facetten zijn nog niet uitgekristalliseerd. Draai `/crystallize &lt;doc&gt;` zodra de vorm stabiel is; de skill stelt facetten, coverage, invarianten en rationale voor vanuit wat het document al bevat. Herhaal met `--refresh` bij structurele wijziging.&quot;,
+      &quot;guideLayer4CrystallizeBody&quot;: &quot;Kristalliseer niet in vroege iteratie — facetten zijn nog niet uitgekristalliseerd. Draai `/crystallize &lt;doc&gt;` zodra de vorm stabiel is; de skill stelt facetten, coverage, invarianten en rationale voor vanuit wat het document al bevat. Herhaal met `--refresh` bij structurele wijziging. Open het Flow-tabblad om facetten en coverage te zien verschijnen terwijl de skill ze wegschrijft.&quot;,
+      &quot;guideLayer4FlowIntro&quot;: &quot;Het Flow-tabblad in de compositor is het primaire oppervlak voor governance. Open een gekristalliseerd document, schakel over naar Flow, en de laag wordt een canvas: facetten links, secties in het midden, invarianten rechts, met getypeerde draden ertussen.&quot;,
+      &quot;guideLayer4FlowFacets&quot;: &quot;In het Flow-canvas: de linkerkolom. Orphan-facetten verschijnen als roze kaarten met een Orphan-badge, zodat gaten in de coverage in één oogopslag zichtbaar zijn. Sleep de rechterpoort van een facet naar de linkerpoort van een sectie om een coverage-edge toe te voegen.&quot;,
+      &quot;guideLayer4FlowCoverage&quot;: &quot;In het Flow-canvas: grijze bezier-draden van de rechterpoort van elk facet naar de linkerpoort van de sectie. Drift (de doelsectie is verwijderd) verschijnt als een gestreepte rode draad die richting de sectiekolom wegloopt. Klik op een draad om hem te verwijderen.&quot;,
+      &quot;guideLayer4FlowInvariants&quot;: &quot;In het Flow-canvas: de rechterkolom, amberen pijlen met pijlpunten wijzen naar de secties die ze beheren. Klik op de Doc-wide-chip van een invariant om `appliesTo: [\&quot;*\&quot;]` om te schakelen; de pijlen klappen samen in één pijl die wijst naar een virtueel anker boven de sectiekolom. Sleep naar een specifieke sectie om opnieuw te scopen.&quot;,
+      &quot;guideLayer4FlowFingerprint&quot;: &quot;In het Flow-canvas: een amberen banner blijft bovenaan hangen wanneer de vingerafdruk verouderd is. Coverage- en invariant-draden vervagen en desatureren zodat de verouderde staat onmiskenbaar is. De Stempel-knop in de banner herberekent en slaat een nieuwe vingerafdruk op; de Kristalliseer-knop kopieert `/crystallize &lt;doc&gt; --refresh` naar het klembord.&quot;,
+      &quot;guideLayer4ReadingTitle&quot;: &quot;Het Flow-canvas lezen&quot;,
+      &quot;guideLayer4ReadingBody&quot;: &quot;Drie kolommen, drie rollen. Twee draadkleuren, twee knooppunttoestanden. Eén cursieve voettekst per sectie.&quot;,
+      &quot;guideLayer4ReadingColumns&quot;: &quot;Kolommen · Doelfacetten (links) → secties (midden) → invarianten (rechts). Elk is een governance-rol uitgedrukt als kolom.&quot;,
+      &quot;guideLayer4ReadingWires&quot;: &quot;Draden · Grijze bezier = coverage (facet wordt gedragen door sectie). Amberen bezier met pijlpunt = invariant (regel beheert sectie). Gestreepte varianten signaleren drift of in-uitvoering-preview.&quot;,
+      &quot;guideLayer4ReadingStates&quot;: &quot;Toestanden · Roze facetkaart + Orphan-badge = geen coverage-edges. Gestreepte rode draad = gedriftet (wijst naar een ontbrekende sectie). Vervaagde + gedesatureerde draden = metaFingerprint is verouderd.&quot;,
+      &quot;guideLayer4ReadingStats&quot;: &quot;Statusbalk · Vastgeprikt bovenaan: facet / sectie / coverage / invariant-aantallen, aangegeven rationale versus totaal, en opvallende labels voor orphan- of drift-aantallen wanneer die niet nul zijn.&quot;,
+      &quot;guideLayer4ReadingRationale&quot;: &quot;Rationale · Cursieve gestippelde kaart onderaan elk sectieknooppunt. Een gestippelde \&quot;nog geen rationale verklaard\&quot;-stub verschijnt wanneer het veld ontbreekt, zodat hiaten in authoring zichtbaar blijven.&quot;,
+      &quot;guideLayer4EditingTitle&quot;: &quot;Bewerken via het Flow-canvas&quot;,
+      &quot;guideLayer4EditingBody&quot;: &quot;Elke interactie schrijft naar dezelfde `docExtras` die `/crystallize` en de tabulaire editor gebruiken, zodat het canvas synchroon blijft met de andere weergaven.&quot;,
+      &quot;guideLayer4EditingDrag&quot;: &quot;Sleep een poort → maak een draad. Facet-uitpoort naar sectie-inpoort voegt coverage toe (kiest een ongebruikte cardId uit de sectie). Invariant-uitpoort naar sectie-rechterpoort voegt die sectie toe aan `appliesTo`, waarbij een bestaande `\&quot;*\&quot;` wordt verwijderd.&quot;,
+      &quot;guideLayer4EditingClick&quot;: &quot;Klik op een draad → verwijder hem. Klik op de Doc-wide-chip van een invariant → schakel doc-brede scope om. Klik op de rationale-kaart van een sectie → bewerk de zin inline via prompt.&quot;,
+      &quot;guideLayer4EditingRemove&quot;: &quot;× bij hover → verwijder een knooppunt. Facetten cascaderen hun coverage; secties laten coverage-edges opzettelijk achter als drift (het visuele signaal blijft zichtbaar); invarianten zijn een schone verwijdering.&quot;,
+      &quot;guideLayer4EditingPosition&quot;: &quot;Sleep een knooppunt-body → verplaatsen op het canvas (`flowPosition` wordt opgeslagen op het knooppunt). Dubbelklik → terug naar kolom. Layout-reset-knop in de statusbalk → wis alle aangepaste posities.&quot;,
+      &quot;guideLayer4DeepTitle&quot;: &quot;Vingerafdruk, versheid en het kristallisatiemoment&quot;,
+      &quot;guideLayer4DeepIntro&quot;: &quot;De vingerafdruk is goedkoop te berekenen en draagt veel gewicht. Begrijpen wat hij hasht, wanneer je hem stempelt en wat versheid betekent, verandert governance van een statisch etiket in een levend contract.&quot;,
+      &quot;guideLayer4DeepHashTitle&quot;: &quot;Wat de vingerafdruk hasht&quot;,
+      &quot;guideLayer4DeepHashBody&quot;: &quot;Een sha256 van elk sectie-id, convergenceType en de geordende kaart-id&#39;s. Stabiel onder proza-bewerkingen binnen kaarten; instabiel wanneer secties worden toegevoegd of verwijderd, hernoemd of geherstructureerd. De keuze is opzettelijk — governance volgt structuur, geen inhoud.&quot;,
+      &quot;guideLayer4DeepMomentTitle&quot;: &quot;Het kristallisatiemoment&quot;,
+      &quot;guideLayer4DeepMomentBody&quot;: &quot;Beschouw het als een git-commit op de betekenis van het document. Vóór de stempel is het document in vormontdekking en zou governance slechte decomposities uitkristalliseren. Na de stempel is governance vastgepind op een exacte structurele staat. Kristalliseer wanneer de vorm stabiel genoeg is dat een week van kleine bewerkingen hem niet opnieuw vormt.&quot;,
+      &quot;guideLayer4DeepStatesTitle&quot;: &quot;Drie toestanden, drie houdingen&quot;,
+      &quot;guideLayer4DeepStatesBody&quot;: &quot;Ontbrekend — geen vingerafdruk, niets om te controleren; agents vallen terug op proza-herafleiding. Vers — opgeslagen komt overeen met huidig; agents richten deterministisch op de juiste kaarten via coverage-edges. Verouderd — opgeslagen verschilt van huidig; draden vervagen en agents moeten terugvallen op proza omdat coverage naar kaarten kan wijzen waarvan de betekenis is verschoven.&quot;,
+      &quot;guideLayer4DeepRitualsTitle&quot;: &quot;Stempelen vs verversen&quot;,
+      &quot;guideLayer4DeepRitualsBody&quot;: &quot;Stempelen (vanuit de Flow-banner) — bereken de sha256 opnieuw en sla hem op. Behoudt bestaande facetten, coverage, invarianten en rationale. Gebruik wanneer de structurele bewerking semantisch-neutraal is (een sectie die je net toevoegde hernoemd, een kaart-id hergeschikt). Verversen via `/crystallize &lt;doc&gt; --refresh` — draai de skill opnieuw. Stelt bijgewerkte facetten en coverage voor voor de nieuwe structuur; behoudt door auteur bewerkte velden. Gebruik wanneer de wijziging werkelijk nieuwe vorm is.&quot;,
+      &quot;guideLayer4DeepBridgeTitle&quot;: &quot;Waarom dit authoring en langdurige coherentie verbindt&quot;,
+      &quot;guideLayer4DeepBridgeBody&quot;: &quot;Zonder vingerafdruk vereist \&quot;is dit document nog coherent?\&quot; bij elke iteratie een LLM-herleest en menselijk oordeel. Met een vingerafdruk is het een hash-vergelijking. Die ineenstorting — van oordeel naar verificatie — is wat een living doc verandert van een eigengereide structuur in een toetsbaar substraat. In de loop van de tijd maakt het empirische evaluatie mogelijk van welke documentvormen daadwerkelijk goed presteren voor zowel mens als agent.&quot;,
       &quot;guideLayer5Title&quot;: &quot;De Woordenschat Uitbreiden&quot;,
       &quot;guideLayer5Tagline&quot;: &quot;Een nieuw convergentietype maken wanneer niets past.&quot;,
       &quot;guideLayer6Title&quot;: &quot;Werken met Living Docs&quot;,
@@ -3537,7 +3836,26 @@
       &quot;preview&quot;: &quot;Pratinjau&quot;,
       &quot;visual&quot;: &quot;Visual&quot;,
       &quot;board&quot;: &quot;Papan&quot;,
+      &quot;flow&quot;: &quot;Flow&quot;,
       &quot;json&quot;: &quot;JSON&quot;,
+      &quot;flowEmptyTitle&quot;: &quot;Kanvas governance&quot;,
+      &quot;flowEmptyBody&quot;: &quot;Tampilan Flow merender lapisan governance dokumen — faset tujuan, edge coverage, invarian, dan rationale — sebagai kanvas. Rendering kanvas mendarat di #47. Tab sudah ada; aliran data menyusul.&quot;,
+      &quot;flowMissingGovernance&quot;: &quot;Dokumen ini belum memiliki data governance. Jalankan /crystallize pada JSON untuk mengisi objectiveFacets, coverage, dan invariants.&quot;,
+      &quot;flowColFacets&quot;: &quot;Faset tujuan&quot;,
+      &quot;flowColSections&quot;: &quot;Seksi&quot;,
+      &quot;flowColInvariants&quot;: &quot;Invarian&quot;,
+      &quot;flowMetaChecking&quot;: &quot;Memeriksa kesegaran meta…&quot;,
+      &quot;flowMetaCheckingBody&quot;: &quot;Menghitung sidik jari seksi saat ini.&quot;,
+      &quot;flowMetaMissingTitle&quot;: &quot;Meta belum disegel.&quot;,
+      &quot;flowMetaMissingBody&quot;: &quot;Jalankan /crystallize untuk menanam objectiveFacets, coverage, invariants, dan metaFingerprint agar drift dapat dideteksi.&quot;,
+      &quot;flowMetaStaleTitle&quot;: &quot;Meta basi.&quot;,
+      &quot;flowMetaStaleBody&quot;: &quot;Seksi berubah sejak meta diturunkan. Edge coverage mungkin menunjuk ke kartu yang salah. Jalankan /crystallize --refresh atau segel sidik jari baru.&quot;,
+      &quot;flowStampNow&quot;: &quot;Segel sidik jari sekarang&quot;,
+      &quot;flowStamping&quot;: &quot;Menyegel…&quot;,
+      &quot;flowStamped&quot;: &quot;Tersegel&quot;,
+      &quot;flowCrystallize&quot;: &quot;Salin prompt /crystallize&quot;,
+      &quot;flowCrystallizeCopied&quot;: &quot;Tersalin&quot;,
+      &quot;flowResetLayout&quot;: &quot;Reset tata letak&quot;,
       &quot;templates&quot;: &quot;Template&quot;,
       &quot;templatesHint&quot;: &quot;Jelajahi template starter dan lanjutan living doc&quot;,
       &quot;templatesIntro&quot;: &quot;Mulai dengan template starter yang sederhana atau langsung pakai bentuk lanjutan yang lebih lengkap.&quot;,
@@ -3844,7 +4162,37 @@
       &quot;guideLayer4FingerprintTitle&quot;: &quot;Sidik jari dan kesegaran&quot;,
       &quot;guideLayer4FingerprintBody&quot;: &quot;Sebuah sha256 dari struktur seksi pada saat kristalisasi. Merender banner ketika seksi bergeser tetapi meta tidak — coverage basi lebih buruk daripada tanpa coverage, sehingga drift menjadi nyaring.&quot;,
       &quot;guideLayer4CrystallizeTitle&quot;: &quot;Penyempurnaan pass-kedua, bukan gerbang authoring&quot;,
-      &quot;guideLayer4CrystallizeBody&quot;: &quot;Jangan mengkristalkan iterasi awal — faset belum mengendap. Jalankan `/crystallize &lt;doc&gt;` saat bentuk sudah stabil; skill mengusulkan faset, coverage, invarian, dan rationale dari apa yang sudah ada di dokumen. Jalankan ulang dengan `--refresh` saat struktur berubah.&quot;,
+      &quot;guideLayer4CrystallizeBody&quot;: &quot;Jangan mengkristalkan iterasi awal — faset belum mengendap. Jalankan `/crystallize &lt;doc&gt;` saat bentuk sudah stabil; skill mengusulkan faset, coverage, invarian, dan rationale dari apa yang sudah ada di dokumen. Jalankan ulang dengan `--refresh` saat struktur berubah. Buka tab Flow untuk melihat faset dan coverage muncul saat skill menuliskannya.&quot;,
+      &quot;guideLayer4FlowIntro&quot;: &quot;Tab Flow di compositor adalah permukaan utama untuk governance. Buka dokumen yang sudah dikristalkan, beralih ke Flow, dan lapisan tersebut menjadi kanvas: faset di kiri, seksi di tengah, invarian di kanan, dengan kabel bertipe di antara mereka.&quot;,
+      &quot;guideLayer4FlowFacets&quot;: &quot;Di kanvas Flow: kolom kiri. Faset orphan dirender sebagai kartu merah muda dengan badge Orphan, sehingga celah dalam coverage terlihat sekilas. Seret port kanan faset ke port kiri seksi untuk menambahkan edge coverage.&quot;,
+      &quot;guideLayer4FlowCoverage&quot;: &quot;Di kanvas Flow: kabel bezier abu-abu dari port kanan setiap faset ke port kiri seksi. Drift (seksi target telah dihapus) muncul sebagai kabel putus-putus merah yang mengarah ke kolom seksi. Klik kabel untuk menghapusnya.&quot;,
+      &quot;guideLayer4FlowInvariants&quot;: &quot;Di kanvas Flow: kolom kanan, panah berwarna kuning kecoklatan dengan kepala panah menunjuk ke seksi yang mereka atur. Klik chip Doc-wide pada invarian untuk beralih `appliesTo: [\&quot;*\&quot;]`; panah-panah itu berkumpul menjadi satu panah yang menunjuk ke jangkar virtual di atas kolom seksi. Seret ke seksi tertentu untuk mengubah cakupan.&quot;,
+      &quot;guideLayer4FlowFingerprint&quot;: &quot;Di kanvas Flow: banner berwarna kuning kecoklatan menempel di atas saat sidik jari basi. Kabel coverage dan invarian meredup dan desaturasi sehingga kondisi basi tak terbantahkan. Tombol Segel di banner menghitung ulang dan menyimpan sidik jari baru; tombol Crystallize menyalin `/crystallize &lt;doc&gt; --refresh` ke clipboard.&quot;,
+      &quot;guideLayer4ReadingTitle&quot;: &quot;Membaca kanvas Flow&quot;,
+      &quot;guideLayer4ReadingBody&quot;: &quot;Tiga kolom, tiga peran. Dua warna kabel, dua kondisi node. Satu footer miring per seksi.&quot;,
+      &quot;guideLayer4ReadingColumns&quot;: &quot;Kolom · Faset tujuan (kiri) → seksi (tengah) → invarian (kanan). Setiap kolom adalah peran governance yang diungkapkan sebagai kolom.&quot;,
+      &quot;guideLayer4ReadingWires&quot;: &quot;Kabel · Bezier abu-abu = coverage (faset dibawa oleh seksi). Bezier kuning kecoklatan dengan kepala panah = invarian (aturan mengatur seksi). Varian putus-putus menandakan drift atau pratinjau dalam progres.&quot;,
+      &quot;guideLayer4ReadingStates&quot;: &quot;Kondisi · Kartu faset merah muda + badge Orphan = tidak ada edge coverage. Kabel putus-putus merah = drift (menunjuk ke seksi yang hilang). Kabel yang meredup + desaturasi = metaFingerprint basi.&quot;,
+      &quot;guideLayer4ReadingStats&quot;: &quot;Bilah stats · Dipatri di atas: jumlah faset / seksi / coverage / invarian, rationale yang dinyatakan vs total, dan pil mencolok untuk jumlah orphan atau drift bila tidak nol.&quot;,
+      &quot;guideLayer4ReadingRationale&quot;: &quot;Rationale · Kartu miring bergaris di bagian bawah setiap node seksi. Stub putus-putus \&quot;belum ada rationale yang dinyatakan\&quot; muncul saat field kosong sehingga celah authoring tetap terlihat.&quot;,
+      &quot;guideLayer4EditingTitle&quot;: &quot;Menyunting lewat kanvas Flow&quot;,
+      &quot;guideLayer4EditingBody&quot;: &quot;Setiap interaksi menulis ke `docExtras` yang sama yang digunakan oleh `/crystallize` dan editor tabulasi, sehingga kanvas tetap sinkron dengan tampilan lain.&quot;,
+      &quot;guideLayer4EditingDrag&quot;: &quot;Seret port → buat kabel. Port-keluar faset ke port-masuk seksi menambahkan coverage (memilih cardId yang belum terpakai dari seksi). Port-keluar invarian ke port-kanan seksi menambahkan seksi itu ke `appliesTo`, menghapus `\&quot;*\&quot;` yang ada.&quot;,
+      &quot;guideLayer4EditingClick&quot;: &quot;Klik kabel → hapus. Klik chip Doc-wide pada invarian → alihkan cakupan doc-wide. Klik kartu rationale seksi → sunting kalimat inline via prompt.&quot;,
+      &quot;guideLayer4EditingRemove&quot;: &quot;× pada hover → hapus node. Faset mencascade coverage-nya; seksi sengaja meninggalkan edge coverage sebagai drift (sinyal visualnya tetap terlihat); invarian adalah penghapusan bersih.&quot;,
+      &quot;guideLayer4EditingPosition&quot;: &quot;Seret body node → reposisi di kanvas (`flowPosition` tersimpan di node). Klik ganda → kembali ke kolom. Tombol reset tata letak di bilah stats → hapus semua posisi khusus.&quot;,
+      &quot;guideLayer4DeepTitle&quot;: &quot;Sidik jari, kesegaran, dan momen kristalisasi&quot;,
+      &quot;guideLayer4DeepIntro&quot;: &quot;Sidik jari murah untuk dihitung dan memikul banyak beban. Memahami apa yang di-hash, kapan menyegelnya, dan apa arti kesegaran mengubah governance dari label statis menjadi kontrak hidup.&quot;,
+      &quot;guideLayer4DeepHashTitle&quot;: &quot;Apa yang di-hash oleh sidik jari&quot;,
+      &quot;guideLayer4DeepHashBody&quot;: &quot;Sebuah sha256 dari setiap id seksi, convergenceType, dan id kartu yang berurutan. Stabil terhadap suntingan prosa di dalam kartu; tidak stabil ketika seksi ditambahkan atau dihapus, diganti nama, atau direstrukturisasi. Pilihannya disengaja — governance mengikuti struktur, bukan konten.&quot;,
+      &quot;guideLayer4DeepMomentTitle&quot;: &quot;Momen kristalisasi&quot;,
+      &quot;guideLayer4DeepMomentBody&quot;: &quot;Anggap ini seperti git commit pada makna dokumen. Sebelum penyegelan, dokumen dalam mode penemuan bentuk dan governance akan mengkristalkan dekomposisi yang buruk. Setelah penyegelan, governance terpaku pada kondisi struktural yang tepat. Kristalkan saat bentuk sudah cukup stabil sehingga seminggu suntingan kecil tidak akan mengubah bentuknya.&quot;,
+      &quot;guideLayer4DeepStatesTitle&quot;: &quot;Tiga kondisi, tiga sikap&quot;,
+      &quot;guideLayer4DeepStatesBody&quot;: &quot;Hilang — tidak ada sidik jari, tidak ada yang diperiksa; agen kembali ke penurunan prosa. Segar — tersimpan cocok dengan saat ini; agen secara deterministik menargetkan kartu yang tepat via edge coverage. Basi — tersimpan berbeda dari saat ini; kabel meredup dan agen harus kembali ke prosa karena coverage mungkin menunjuk ke kartu yang maknanya telah bergeser.&quot;,
+      &quot;guideLayer4DeepRitualsTitle&quot;: &quot;Segel vs segarkan&quot;,
+      &quot;guideLayer4DeepRitualsBody&quot;: &quot;Segel (dari banner Flow) — hitung ulang sha256 dan simpan. Mempertahankan faset, coverage, invarian, dan rationale yang ada. Gunakan ketika suntingan struktural netral-semantik (nama seksi yang baru saja ditambahkan, id kartu yang diatur ulang). Segarkan via `/crystallize &lt;doc&gt; --refresh` — jalankan ulang skill. Mengusulkan faset dan coverage yang diperbarui untuk struktur baru; mempertahankan field yang disunting penulis. Gunakan ketika perubahan benar-benar bentuk baru.&quot;,
+      &quot;guideLayer4DeepBridgeTitle&quot;: &quot;Mengapa ini menjembatani authoring dan koherensi jangka panjang&quot;,
+      &quot;guideLayer4DeepBridgeBody&quot;: &quot;Tanpa sidik jari, pertanyaan \&quot;apakah dokumen ini masih koheren?\&quot; membutuhkan pembacaan ulang LLM dan penilaian manusia pada setiap iterasi. Dengan sidik jari, ini adalah perbandingan hash. Pelipatan itu — dari penilaian ke verifikasi — yang mengubah living doc dari struktur beropini menjadi substrat yang dapat diuji. Seiring waktu memungkinkan evaluasi empiris terhadap bentuk dokumen mana yang benar-benar bekerja baik untuk pembaca manusia maupun agen.&quot;,
       &quot;guideLayer5Title&quot;: &quot;Memperluas Kosakata&quot;,
       &quot;guideLayer5Tagline&quot;: &quot;Membuat tipe konvergensi baru ketika yang ada tidak cocok.&quot;,
       &quot;guideLayer6Title&quot;: &quot;Bekerja dengan Living Docs&quot;,
@@ -4049,10 +4397,13 @@
     return String(value || &#39;&#39;).toLowerCase().replace(/[^a-z0-9]+/g, &#39;-&#39;).replace(/^-|-$/g, &#39;&#39;).slice(0, 64);
   }
   function govSectionSignature() {
+    // Key names must match scripts/meta-fingerprint.mjs exactly — the Node
+    // stamper and this browser check produce different sha256 hashes otherwise,
+    // and every crystallized doc reads as stale in the Flow view. See #58.
     return JSON.stringify((state.sections || []).map((s) =&gt; ({
       id: String(s?.id || &#39;&#39;),
-      t: String(s?.convergenceType || &#39;&#39;),
-      c: (Array.isArray(s?.data) ? s.data : []).map((item) =&gt; String(item?.id || &#39;&#39;)).filter(Boolean),
+      type: String(s?.convergenceType || &#39;&#39;),
+      cards: (Array.isArray(s?.data) ? s.data : []).map((item) =&gt; String(item?.id || &#39;&#39;)).filter(Boolean),
     })));
   }
   async function govComputeFingerprint() {
@@ -10424,7 +10775,7 @@
     autoSave();
     const panel = document.getElementById(&#39;right-panel&#39;);
 
-    if (![&#39;visual&#39;, &#39;board&#39;, &#39;json&#39;].includes(state.previewTab)) state.previewTab = &#39;visual&#39;;
+    if (![&#39;visual&#39;, &#39;board&#39;, &#39;flow&#39;, &#39;json&#39;].includes(state.previewTab)) state.previewTab = &#39;visual&#39;;
     const json = buildJson();
     const title = t(&#39;preview&#39;);
 
@@ -10434,15 +10785,18 @@
         &lt;div class=&quot;preview-tabs&quot;&gt;
           &lt;button class=&quot;preview-tab${state.previewTab === &#39;visual&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;visual&quot;&gt;${esc(t(&#39;visual&#39;))}&lt;/button&gt;
           &lt;button class=&quot;preview-tab${state.previewTab === &#39;board&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;board&quot;&gt;${esc(t(&#39;board&#39;))}&lt;/button&gt;
+          &lt;button class=&quot;preview-tab${state.previewTab === &#39;flow&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;flow&quot;&gt;${esc(t(&#39;flow&#39;))}&lt;/button&gt;
           &lt;button class=&quot;preview-tab${state.previewTab === &#39;json&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;json&quot;&gt;${esc(t(&#39;json&#39;))}&lt;/button&gt;
         &lt;/div&gt;
       &lt;/div&gt;
-      &lt;div class=&quot;preview-content&quot;&gt;
+      &lt;div class=&quot;preview-content${state.previewTab === &#39;flow&#39; ? &#39; preview-content-flow&#39; : &#39;&#39;}&quot;&gt;
         ${state.previewTab === &#39;json&#39;
           ? renderJsonPreview(json)
           : state.previewTab === &#39;board&#39;
             ? renderBoardPreview(json)
-            : renderVisualPreview(json)}
+            : state.previewTab === &#39;flow&#39;
+              ? renderFlowPreview(json)
+              : renderVisualPreview(json)}
       &lt;/div&gt;`;
 
     panel.querySelectorAll(&#39;.preview-tab&#39;).forEach(tab =&gt; {
@@ -10680,8 +11034,344 @@
       refreshFingerprintPill();
     }
 
+    if (state.previewTab === &#39;flow&#39;) {
+      requestAnimationFrame(() =&gt; drawFlowWires(json));
+      wireFlowInteractions(panel);
+    }
+
     syncFocusedSectionInPreview();
   }
+
+  let flowResizeHandler = null;
+  function ensureFlowResizeHook() {
+    if (flowResizeHandler) return;
+    flowResizeHandler = () =&gt; {
+      if (state.previewTab !== &#39;flow&#39;) return;
+      requestAnimationFrame(() =&gt; drawFlowWires(buildJson()));
+    };
+    window.addEventListener(&#39;resize&#39;, flowResizeHandler);
+  }
+  ensureFlowResizeHook();
+
+  function flowRerender() {
+    autoSave();
+    renderRight();
+  }
+
+  function wireFlowInteractions(panel) {
+    const canvas = panel.querySelector(&#39;#flow-canvas&#39;);
+    const wrap = panel.querySelector(&#39;#flow-canvas-wrap&#39;);
+    if (!canvas || !wrap) return;
+
+    // Remove a node (facet / section / invariant)
+    canvas.querySelectorAll(&#39;[data-flow-remove]&#39;).forEach((btn) =&gt; {
+      btn.addEventListener(&#39;click&#39;, (event) =&gt; {
+        event.stopPropagation();
+        const kind = btn.dataset.flowRemove;
+        const id = btn.dataset.flowId;
+        if (kind === &#39;facet&#39;) {
+          govSetFacets(govFacets().filter((f) =&gt; f.id !== id));
+          govSetCoverage(govCoverage().filter((c) =&gt; c.facetId !== id));
+        } else if (kind === &#39;invariant&#39;) {
+          govSetInvariants(govInvariants().filter((i) =&gt; i.id !== id));
+        } else if (kind === &#39;section&#39;) {
+          state.sections = state.sections.filter((s) =&gt; s.id !== id);
+          // coverage edges to the removed section become drift — keep them.
+        }
+        flowRerender();
+      });
+    });
+
+    // Remove a wire (coverage or invariant applies-to entry) via delegation,
+    // because wires are drawn async via requestAnimationFrame after this runs.
+    canvas.addEventListener(&#39;click&#39;, (event) =&gt; {
+      const hit = event.target.closest(&#39;[data-flow-edge]&#39;);
+      if (!hit) return;
+      const edgeKind = hit.dataset.flowEdge;
+      if (edgeKind === &#39;coverage&#39;) {
+        const idx = Number(hit.dataset.flowEdgeIndex);
+        const coverage = [...govCoverage()];
+        coverage.splice(idx, 1);
+        govSetCoverage(coverage);
+      } else if (edgeKind === &#39;invariant&#39;) {
+        const invIdx = Number(hit.dataset.flowInvIndex);
+        const tgtIdx = Number(hit.dataset.flowTargetIndex);
+        const invariants = [...govInvariants()];
+        if (invariants[invIdx] &amp;&amp; Array.isArray(invariants[invIdx].appliesTo)) {
+          invariants[invIdx] = {
+            ...invariants[invIdx],
+            appliesTo: invariants[invIdx].appliesTo.filter((_, i) =&gt; i !== tgtIdx),
+          };
+          govSetInvariants(invariants);
+        }
+      }
+      flowRerender();
+    });
+
+    // Toggle doc-wide invariant
+    canvas.querySelectorAll(&#39;[data-flow-docwide]&#39;).forEach((btn) =&gt; {
+      btn.addEventListener(&#39;click&#39;, (event) =&gt; {
+        event.stopPropagation();
+        const invId = btn.dataset.flowDocwide;
+        const invariants = [...govInvariants()];
+        const idx = invariants.findIndex((i) =&gt; i.id === invId);
+        if (idx &lt; 0) return;
+        const applies = Array.isArray(invariants[idx].appliesTo) ? [...invariants[idx].appliesTo] : [];
+        const hasStar = applies.includes(&#39;*&#39;);
+        invariants[idx] = {
+          ...invariants[idx],
+          appliesTo: hasStar ? applies.filter((a) =&gt; a !== &#39;*&#39;) : [&#39;*&#39;],
+        };
+        govSetInvariants(invariants);
+        flowRerender();
+      });
+    });
+
+    // Inline-edit rationale
+    canvas.querySelectorAll(&#39;.flow-rationale&#39;).forEach((el) =&gt; {
+      el.addEventListener(&#39;click&#39;, (event) =&gt; {
+        event.stopPropagation();
+        const sectionNode = el.closest(&#39;[data-flow-kind=&quot;section&quot;]&#39;);
+        if (!sectionNode) return;
+        const sid = sectionNode.dataset.flowId;
+        const section = state.sections.find((s) =&gt; s.id === sid);
+        if (!section) return;
+        const next = window.prompt(&#39;Rationale \u2014 why this convergence type, here:&#39;, section.rationale || &#39;&#39;);
+        if (next === null) return;
+        const trimmed = next.trim();
+        if (trimmed) section.rationale = trimmed; else delete section.rationale;
+        flowRerender();
+      });
+    });
+
+    // Freshness banner — async fingerprint check after render.
+    const banner = panel.querySelector(&#39;#flow-banner&#39;);
+    const stamp = panel.querySelector(&#39;[data-flow-stamp]&#39;);
+    const crystBtn = panel.querySelector(&#39;[data-flow-crystallize]&#39;);
+    const bannerTitle = panel.querySelector(&#39;#flow-banner-title&#39;);
+    const bannerMsg = panel.querySelector(&#39;#flow-banner-message&#39;);
+    const applyBannerState = async () =&gt; {
+      if (!banner || !wrap) return;
+      const stored = govFingerprint();
+      if (!stored) {
+        banner.dataset.state = &#39;missing&#39;;
+        wrap.classList.remove(&#39;flow-stale&#39;);
+        bannerTitle.textContent = t(&#39;flowMetaMissingTitle&#39;);
+        bannerMsg.textContent = t(&#39;flowMetaMissingBody&#39;);
+        return;
+      }
+      const current = await govComputeFingerprint();
+      if (!current || current === stored) {
+        banner.dataset.state = &#39;fresh&#39;;
+        banner.style.display = &#39;none&#39;;
+        wrap.classList.remove(&#39;flow-stale&#39;);
+        return;
+      }
+      banner.dataset.state = &#39;stale&#39;;
+      banner.style.display = &#39;&#39;;
+      wrap.classList.add(&#39;flow-stale&#39;);
+      bannerTitle.textContent = t(&#39;flowMetaStaleTitle&#39;);
+      bannerMsg.textContent = t(&#39;flowMetaStaleBody&#39;);
+    };
+    if (banner) {
+      banner.style.display = &#39;&#39;;
+      applyBannerState();
+    }
+
+    stamp?.addEventListener(&#39;click&#39;, async (event) =&gt; {
+      const btn = event.currentTarget;
+      const original = btn.textContent;
+      btn.disabled = true;
+      btn.textContent = t(&#39;flowStamping&#39;);
+      try {
+        const fp = await govComputeFingerprint();
+        if (fp) {
+          govSetFingerprint(fp);
+          btn.textContent = t(&#39;flowStamped&#39;);
+          setTimeout(() =&gt; { btn.disabled = false; btn.textContent = original; flowRerender(); }, 900);
+        } else {
+          btn.textContent = original;
+          btn.disabled = false;
+        }
+      } catch (err) {
+        btn.textContent = original;
+        btn.disabled = false;
+      }
+    });
+
+    crystBtn?.addEventListener(&#39;click&#39;, async (event) =&gt; {
+      const btn = event.currentTarget;
+      const label = currentOriginLabel() || &#39;&lt;path/to/doc.json&gt;&#39;;
+      const isStale = banner?.dataset.state === &#39;stale&#39;;
+      const prompt = `/crystallize ${label}${isStale ? &#39; --refresh&#39; : &#39;&#39;}`;
+      const original = btn.textContent;
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(prompt);
+          btn.textContent = t(&#39;flowCrystallizeCopied&#39;);
+        } else {
+          window.prompt(&#39;Copy this prompt:&#39;, prompt);
+        }
+      } catch (err) {
+        window.prompt(&#39;Copy this prompt:&#39;, prompt);
+      }
+      setTimeout(() =&gt; { btn.textContent = original; }, 1600);
+    });
+
+    // Reset-layout button
+    panel.querySelector(&#39;[data-flow-reset-layout]&#39;)?.addEventListener(&#39;click&#39;, () =&gt; {
+      const facets = govFacets().map(({ flowPosition, ...rest }) =&gt; rest);
+      const invariants = govInvariants().map(({ flowPosition, ...rest }) =&gt; rest);
+      govSetFacets(facets);
+      govSetInvariants(invariants);
+      state.sections = state.sections.map(({ flowPosition, ...rest }) =&gt; rest);
+      flowRerender();
+    });
+
+    // Double-click a node to clear its flowPosition
+    canvas.querySelectorAll(&#39;.flow-node&#39;).forEach((node) =&gt; {
+      node.addEventListener(&#39;dblclick&#39;, (event) =&gt; {
+        if (event.target.closest(&#39;.flow-port, .flow-remove, [data-flow-docwide], .flow-rationale, [data-flow-reset-layout]&#39;)) return;
+        const kind = node.dataset.flowKind;
+        const id = node.dataset.flowId;
+        if (kind === &#39;facet&#39;) {
+          govSetFacets(govFacets().map((f) =&gt; f.id === id ? (({ flowPosition, ...r }) =&gt; r)(f) : f));
+        } else if (kind === &#39;invariant&#39;) {
+          govSetInvariants(govInvariants().map((i) =&gt; i.id === id ? (({ flowPosition, ...r }) =&gt; r)(i) : i));
+        } else if (kind === &#39;section&#39;) {
+          state.sections = state.sections.map((s) =&gt; s.id === id ? (({ flowPosition, ...r }) =&gt; r)(s) : s);
+        }
+        flowRerender();
+      });
+    });
+
+    // Drag a node body to reposition. Threshold distinguishes drag from click.
+    canvas.querySelectorAll(&#39;.flow-node&#39;).forEach((node) =&gt; {
+      node.addEventListener(&#39;pointerdown&#39;, (event) =&gt; {
+        if (event.target.closest(&#39;.flow-port, .flow-remove, [data-flow-docwide], .flow-rationale, [data-flow-reset-layout]&#39;)) return;
+        if (event.target.closest(&#39;[data-flow-edge]&#39;)) return;
+        event.preventDefault();
+        const canvasRect = canvas.getBoundingClientRect();
+        const nodeRect = node.getBoundingClientRect();
+        const offX = event.clientX - nodeRect.left;
+        const offY = event.clientY - nodeRect.top;
+        const startClientX = event.clientX;
+        const startClientY = event.clientY;
+        let dragging = false;
+        const onMove = (ev) =&gt; {
+          const dx = ev.clientX - startClientX;
+          const dy = ev.clientY - startClientY;
+          if (!dragging &amp;&amp; Math.hypot(dx, dy) &lt; 4) return;
+          dragging = true;
+          const currentCanvasRect = canvas.getBoundingClientRect();
+          const x = Math.max(0, ev.clientX - currentCanvasRect.left - offX);
+          const y = Math.max(0, ev.clientY - currentCanvasRect.top - offY);
+          node.classList.add(&#39;flow-node-dragging&#39;);
+          node.dataset.flowPositioned = &#39;true&#39;;
+          node.style.left = x + &#39;px&#39;;
+          node.style.top = y + &#39;px&#39;;
+          requestAnimationFrame(() =&gt; drawFlowWires(buildJson()));
+        };
+        const onUp = (ev) =&gt; {
+          document.removeEventListener(&#39;pointermove&#39;, onMove);
+          document.removeEventListener(&#39;pointerup&#39;, onUp);
+          node.classList.remove(&#39;flow-node-dragging&#39;);
+          if (!dragging) return;
+          const finalRect = node.getBoundingClientRect();
+          const finalCanvasRect = canvas.getBoundingClientRect();
+          const x = Math.round(finalRect.left - finalCanvasRect.left);
+          const y = Math.round(finalRect.top - finalCanvasRect.top);
+          const kind = node.dataset.flowKind;
+          const id = node.dataset.flowId;
+          if (kind === &#39;facet&#39;) {
+            govSetFacets(govFacets().map((f) =&gt; f.id === id ? { ...f, flowPosition: { x, y } } : f));
+          } else if (kind === &#39;invariant&#39;) {
+            govSetInvariants(govInvariants().map((i) =&gt; i.id === id ? { ...i, flowPosition: { x, y } } : i));
+          } else if (kind === &#39;section&#39;) {
+            state.sections = state.sections.map((s) =&gt; s.id === id ? { ...s, flowPosition: { x, y } } : s);
+          }
+          flowRerender();
+        };
+        document.addEventListener(&#39;pointermove&#39;, onMove);
+        document.addEventListener(&#39;pointerup&#39;, onUp);
+      });
+    });
+
+    // Drag to create a wire
+    canvas.querySelectorAll(&#39;[data-port=&quot;facet-out&quot;]&#39;).forEach((port) =&gt; {
+      port.addEventListener(&#39;pointerdown&#39;, (event) =&gt; {
+        event.preventDefault();
+        flowDragState = { kind: &#39;coverage&#39;, fromId: port.dataset.facetId, mouseX: event.clientX, mouseY: event.clientY };
+        port.classList.add(&#39;flow-port-dragging&#39;);
+        drawFlowWires(buildJson());
+      });
+    });
+    canvas.querySelectorAll(&#39;[data-port=&quot;inv-out&quot;]&#39;).forEach((port) =&gt; {
+      port.addEventListener(&#39;pointerdown&#39;, (event) =&gt; {
+        event.preventDefault();
+        flowDragState = { kind: &#39;invariant&#39;, fromId: port.dataset.invariantId, mouseX: event.clientX, mouseY: event.clientY };
+        port.classList.add(&#39;flow-port-dragging-inv&#39;);
+        drawFlowWires(buildJson());
+      });
+    });
+  }
+
+  // Global pointer handlers for the drag — simpler to keep on document.
+  let flowGlobalPointerHandlers = null;
+  function ensureFlowGlobalPointerHandlers() {
+    if (flowGlobalPointerHandlers) return;
+    flowGlobalPointerHandlers = {
+      move: (event) =&gt; {
+        if (!flowDragState) return;
+        flowDragState.mouseX = event.clientX;
+        flowDragState.mouseY = event.clientY;
+        drawFlowWires(buildJson());
+      },
+      up: (event) =&gt; {
+        if (!flowDragState) return;
+        document.querySelectorAll(&#39;.flow-port.flow-port-dragging, .flow-port.flow-port-dragging-inv&#39;)
+          .forEach((el) =&gt; el.classList.remove(&#39;flow-port-dragging&#39;, &#39;flow-port-dragging-inv&#39;));
+        const drag = flowDragState;
+        flowDragState = null;
+        const dropTarget = document.elementFromPoint(event.clientX, event.clientY);
+        if (drag.kind === &#39;coverage&#39;) {
+          const inPort = dropTarget?.closest(&#39;[data-port=&quot;section-in&quot;]&#39;);
+          if (inPort) {
+            const sectionId = inPort.dataset.sectionId;
+            const facetId = drag.fromId;
+            const section = state.sections.find((s) =&gt; s.id === sectionId);
+            const usedCards = new Set(govCoverage().filter((c) =&gt; c.sectionId === sectionId).map((c) =&gt; c.cardId));
+            const cardId = (section?.data || []).map((d) =&gt; d?.id).filter(Boolean).find((c) =&gt; !usedCards.has(c))
+              || (section?.data || []).map((d) =&gt; d?.id).filter(Boolean)[0]
+              || &#39;&#39;;
+            const exists = govCoverage().some((c) =&gt; c.facetId === facetId &amp;&amp; c.sectionId === sectionId &amp;&amp; (c.cardId || &#39;&#39;) === cardId);
+            if (!exists) {
+              govSetCoverage([...govCoverage(), cardId ? { facetId, sectionId, cardId } : { facetId, sectionId }]);
+            }
+          }
+        } else if (drag.kind === &#39;invariant&#39;) {
+          const invInPort = dropTarget?.closest(&#39;[data-port=&quot;section-inv-in&quot;]&#39;);
+          if (invInPort) {
+            const sectionId = invInPort.dataset.sectionId;
+            const invariants = [...govInvariants()];
+            const idx = invariants.findIndex((i) =&gt; i.id === drag.fromId);
+            if (idx &gt;= 0) {
+              const applies = Array.isArray(invariants[idx].appliesTo) ? [...invariants[idx].appliesTo] : [];
+              const starIdx = applies.indexOf(&#39;*&#39;);
+              if (starIdx &gt;= 0) applies.splice(starIdx, 1);
+              if (!applies.includes(sectionId)) applies.push(sectionId);
+              invariants[idx] = { ...invariants[idx], appliesTo: applies };
+              govSetInvariants(invariants);
+            }
+          }
+        }
+        flowRerender();
+      },
+    };
+    document.addEventListener(&#39;pointermove&#39;, flowGlobalPointerHandlers.move);
+    document.addEventListener(&#39;pointerup&#39;,   flowGlobalPointerHandlers.up);
+  }
+  ensureFlowGlobalPointerHandlers();
 
   function renderTemplatesView() {
     if (!TEMPLATES.length) {
@@ -10762,6 +11452,261 @@
         ${renderTemplateGroup(&#39;starterTemplates&#39;, &#39;starterTemplatesIntro&#39;, starterTemplates)}
         ${renderTemplateGroup(&#39;advancedTemplates&#39;, &#39;advancedTemplatesIntro&#39;, advancedTemplates)}
       &lt;/div&gt;`;
+  }
+
+  function deriveFlowCoherence(json) {
+    const facets = Array.isArray(json.objectiveFacets) ? json.objectiveFacets : [];
+    const coverage = Array.isArray(json.coverage) ? json.coverage : [];
+    const invariants = Array.isArray(json.invariants) ? json.invariants : [];
+    const sections = Array.isArray(json.sections) ? json.sections : [];
+    const knownSectionIds = new Set(sections.map((s) =&gt; s.id));
+    const facetStatus = new Map();
+    for (const facet of facets) {
+      const edges = coverage.filter((c) =&gt; c.facetId === facet.id);
+      const carryingSectionIds = [...new Set(edges.map((e) =&gt; e.sectionId))];
+      const anyDrift = edges.some((e) =&gt; !knownSectionIds.has(e.sectionId));
+      let status;
+      if (anyDrift) status = &#39;drift&#39;;
+      else if (edges.length === 0) status = &#39;orphaned&#39;;
+      else status = &#39;covered&#39;;
+      facetStatus.set(facet.id, { status, carryingSectionIds });
+    }
+    return { facets, coverage, invariants, sections, knownSectionIds, facetStatus };
+  }
+
+  function renderFlowPreview(json) {
+    const state = deriveFlowCoherence(json);
+    const { facets, coverage, invariants, sections } = state;
+    const hasGovernance = facets.length &gt; 0 || coverage.length &gt; 0 || invariants.length &gt; 0;
+
+    if (!hasGovernance) {
+      return `
+        &lt;div class=&quot;flow-empty&quot;&gt;
+          &lt;strong&gt;${esc(t(&#39;flowEmptyTitle&#39;))}&lt;/strong&gt;
+          ${esc(t(&#39;flowMissingGovernance&#39;))}
+        &lt;/div&gt;`;
+    }
+
+    const orphanCount = [...state.facetStatus.values()].filter((v) =&gt; v.status === &#39;orphaned&#39;).length;
+    const driftCount = [...state.facetStatus.values()].filter((v) =&gt; v.status === &#39;drift&#39;).length;
+    const rationalesDeclared = sections.filter((s) =&gt; (s.rationale || &#39;&#39;).trim().length &gt; 0).length;
+    const invArrows = invariants.reduce((n, inv) =&gt; n + (Array.isArray(inv.appliesTo) ? inv.appliesTo.length : 0), 0);
+
+    const anyPositioned =
+      facets.some((f) =&gt; f.flowPosition) ||
+      sections.some((s) =&gt; s.flowPosition) ||
+      invariants.some((i) =&gt; i.flowPosition);
+
+    const statsHtml = `
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${facets.length}&lt;/strong&gt; facets&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${sections.length}&lt;/strong&gt; sections&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${coverage.length}&lt;/strong&gt; coverage edges&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${invariants.length}&lt;/strong&gt; invariants \u00b7 ${invArrows} arrows&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${rationalesDeclared}/${sections.length}&lt;/strong&gt; rationales&lt;/span&gt;
+      ${orphanCount &gt; 0 ? `&lt;span class=&quot;flow-stat flow-stat-bad&quot;&gt;&lt;strong&gt;${orphanCount}&lt;/strong&gt; orphaned&lt;/span&gt;` : &#39;&#39;}
+      ${driftCount &gt; 0 ? `&lt;span class=&quot;flow-stat flow-stat-warn&quot;&gt;&lt;strong&gt;${driftCount}&lt;/strong&gt; drifted&lt;/span&gt;` : &#39;&#39;}
+      ${anyPositioned ? `&lt;button type=&quot;button&quot; class=&quot;flow-reset-layout-btn&quot; data-flow-reset-layout title=&quot;Clear all flowPosition values&quot;&gt;${esc(t(&#39;flowResetLayout&#39;))}&lt;/button&gt;` : &#39;&#39;}`;
+
+    const positionStyle = (node) =&gt; {
+      const p = node?.flowPosition;
+      if (!p || typeof p !== &#39;object&#39;) return &#39;&#39;;
+      const x = Number.isFinite(p.x) ? p.x : 0;
+      const y = Number.isFinite(p.y) ? p.y : 0;
+      return ` data-flow-positioned=&quot;true&quot; style=&quot;left:${x}px;top:${y}px&quot;`;
+    };
+
+    const facetsHtml = facets.map((facet) =&gt; {
+      const { status } = state.facetStatus.get(facet.id) || { status: &#39;orphaned&#39; };
+      const orphan = status === &#39;orphaned&#39;;
+      return `
+        &lt;article class=&quot;flow-node ${orphan ? &#39;flow-node-orphan&#39; : &#39;&#39;}&quot; data-flow-kind=&quot;facet&quot; data-flow-id=&quot;${esc(facet.id)}&quot;${positionStyle(facet)}&gt;
+          &lt;button type=&quot;button&quot; class=&quot;flow-remove&quot; data-flow-remove=&quot;facet&quot; data-flow-id=&quot;${esc(facet.id)}&quot; title=&quot;Remove facet&quot;&gt;\u00d7&lt;/button&gt;
+          &lt;div class=&quot;flow-node-header&quot;&gt;
+            &lt;h5&gt;${esc(facet.name || facet.id)}&lt;/h5&gt;
+            ${orphan ? `&lt;span class=&quot;flow-badge flow-badge-orphan&quot;&gt;Orphan&lt;/span&gt;` : &#39;&#39;}
+          &lt;/div&gt;
+          &lt;div class=&quot;flow-node-id&quot;&gt;${esc(facet.id)}&lt;/div&gt;
+          ${facet.description ? `&lt;div class=&quot;flow-node-body&quot;&gt;${esc(facet.description)}&lt;/div&gt;` : &#39;&#39;}
+          &lt;span class=&quot;flow-port flow-port-out&quot; data-port=&quot;facet-out&quot; data-facet-id=&quot;${esc(facet.id)}&quot; title=&quot;Drag to a section&#39;s left port to add coverage&quot;&gt;&lt;/span&gt;
+        &lt;/article&gt;`;
+    }).join(&#39;&#39;);
+
+    const sectionsHtml = sections.map((section) =&gt; {
+      const rationale = (section.rationale || &#39;&#39;).trim();
+      const rationaleHtml = rationale
+        ? `&lt;div class=&quot;flow-rationale&quot;&gt;${esc(rationale)}&lt;/div&gt;`
+        : `&lt;div class=&quot;flow-rationale flow-rationale-empty&quot;&gt;\u2014 no rationale declared yet \u2014&lt;/div&gt;`;
+      const cards = Array.isArray(section.data) ? section.data : [];
+      const chips = cards.filter((c) =&gt; c &amp;&amp; c.id).slice(0, 8).map((c) =&gt; `&lt;span class=&quot;flow-card-chip&quot;&gt;${esc(c.id)}&lt;/span&gt;`).join(&#39;&#39;);
+      const overflow = cards.filter((c) =&gt; c &amp;&amp; c.id).length - 8;
+      return `
+        &lt;article class=&quot;flow-node&quot; data-flow-kind=&quot;section&quot; data-flow-id=&quot;${esc(section.id)}&quot;${positionStyle(section)}&gt;
+          &lt;button type=&quot;button&quot; class=&quot;flow-remove&quot; data-flow-remove=&quot;section&quot; data-flow-id=&quot;${esc(section.id)}&quot; title=&quot;Remove section&quot;&gt;\u00d7&lt;/button&gt;
+          &lt;div class=&quot;flow-node-header&quot;&gt;
+            &lt;h5&gt;${esc(section.title || section.id)}&lt;/h5&gt;
+            &lt;span class=&quot;flow-badge flow-badge-ct&quot;&gt;${esc(section.convergenceType || &#39;&#39;)}&lt;/span&gt;
+          &lt;/div&gt;
+          &lt;div class=&quot;flow-node-id&quot;&gt;${esc(section.id)}&lt;/div&gt;
+          ${chips ? `&lt;div class=&quot;flow-card-chips&quot;&gt;${chips}${overflow &gt; 0 ? `&lt;span class=&quot;flow-card-chip&quot;&gt;+${overflow}&lt;/span&gt;` : &#39;&#39;}&lt;/div&gt;` : &#39;&#39;}
+          ${rationaleHtml}
+          &lt;span class=&quot;flow-port flow-port-in-left&quot; data-port=&quot;section-in&quot; data-section-id=&quot;${esc(section.id)}&quot; title=&quot;Coverage in-port&quot;&gt;&lt;/span&gt;
+          &lt;span class=&quot;flow-port flow-port-in-right&quot; data-port=&quot;section-inv-in&quot; data-section-id=&quot;${esc(section.id)}&quot; title=&quot;Invariant applies-to in-port&quot;&gt;&lt;/span&gt;
+        &lt;/article&gt;`;
+    }).join(&#39;&#39;);
+
+    const invariantsHtml = invariants.map((inv) =&gt; {
+      const applies = Array.isArray(inv.appliesTo) ? inv.appliesTo : [];
+      const docWide = applies.includes(&#39;*&#39;);
+      const docWideTitle = docWide
+        ? &#39;Doc-wide — click to scope to individual sections&#39;
+        : &#39;Click to make doc-wide (appliesTo: [&quot;*&quot;]); removes any section-specific entries&#39;;
+      return `
+        &lt;article class=&quot;flow-node flow-invariant&quot; data-flow-kind=&quot;invariant&quot; data-flow-id=&quot;${esc(inv.id)}&quot;${positionStyle(inv)}&gt;
+          &lt;button type=&quot;button&quot; class=&quot;flow-remove&quot; data-flow-remove=&quot;invariant&quot; data-flow-id=&quot;${esc(inv.id)}&quot; title=&quot;Remove invariant&quot;&gt;\u00d7&lt;/button&gt;
+          &lt;div class=&quot;flow-node-header&quot;&gt;
+            &lt;h5&gt;${esc(inv.name || inv.id)}&lt;/h5&gt;
+            &lt;button type=&quot;button&quot; class=&quot;flow-badge flow-badge-docwide${docWide ? &#39; flow-badge-docwide-active&#39; : &#39;&#39;}&quot; data-flow-docwide=&quot;${esc(inv.id)}&quot; title=&quot;${esc(docWideTitle)}&quot;&gt;Doc-wide&lt;/button&gt;
+          &lt;/div&gt;
+          &lt;div class=&quot;flow-node-id&quot;&gt;${esc(inv.id)}&lt;/div&gt;
+          ${inv.statement ? `&lt;div class=&quot;flow-invariant-statement&quot;&gt;${esc(inv.statement)}&lt;/div&gt;` : &#39;&#39;}
+          &lt;span class=&quot;flow-port flow-port-inv-out&quot; data-port=&quot;inv-out&quot; data-invariant-id=&quot;${esc(inv.id)}&quot; title=&quot;Drag to a section&#39;s right port to govern it&quot;&gt;&lt;/span&gt;
+        &lt;/article&gt;`;
+    }).join(&#39;&#39;);
+
+    return `
+      &lt;div class=&quot;flow-view&quot; id=&quot;flow-view&quot;&gt;
+        &lt;div class=&quot;flow-banner&quot; id=&quot;flow-banner&quot; data-state=&quot;checking&quot;&gt;
+          &lt;div class=&quot;flow-banner-body&quot;&gt;&lt;strong id=&quot;flow-banner-title&quot;&gt;${esc(t(&#39;flowMetaChecking&#39;))}&lt;/strong&gt; &lt;span id=&quot;flow-banner-message&quot;&gt;${esc(t(&#39;flowMetaCheckingBody&#39;))}&lt;/span&gt;&lt;/div&gt;
+          &lt;div class=&quot;flow-banner-actions&quot;&gt;
+            &lt;button type=&quot;button&quot; class=&quot;flow-banner-btn&quot; data-flow-stamp&gt;${esc(t(&#39;flowStampNow&#39;))}&lt;/button&gt;
+            &lt;button type=&quot;button&quot; class=&quot;flow-banner-btn flow-banner-btn-primary&quot; data-flow-crystallize&gt;${esc(t(&#39;flowCrystallize&#39;))}&lt;/button&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class=&quot;flow-stats&quot;&gt;${statsHtml}&lt;/div&gt;
+        &lt;div class=&quot;flow-canvas-wrap&quot; id=&quot;flow-canvas-wrap&quot;&gt;
+          &lt;div class=&quot;flow-canvas&quot; id=&quot;flow-canvas&quot;&gt;
+            &lt;svg class=&quot;flow-wires&quot; id=&quot;flow-wires&quot; aria-hidden=&quot;true&quot;&gt;
+              &lt;defs&gt;
+                &lt;marker id=&quot;flow-arrow-inv&quot; viewBox=&quot;0 0 10 10&quot; refX=&quot;9&quot; refY=&quot;5&quot; markerWidth=&quot;6&quot; markerHeight=&quot;6&quot; orient=&quot;auto-start-reverse&quot;&gt;
+                  &lt;path d=&quot;M 0 0 L 10 5 L 0 10 z&quot; fill=&quot;#d97706&quot;/&gt;
+                &lt;/marker&gt;
+              &lt;/defs&gt;
+            &lt;/svg&gt;
+            &lt;div class=&quot;flow-col flow-col-facets&quot;&gt;
+              &lt;h4&gt;${esc(t(&#39;flowColFacets&#39;))}&lt;span class=&quot;flow-col-count&quot;&gt;${facets.length}&lt;/span&gt;&lt;/h4&gt;
+              &lt;div class=&quot;flow-nodes&quot;&gt;${facetsHtml}&lt;/div&gt;
+            &lt;/div&gt;
+            &lt;div class=&quot;flow-col flow-col-sections&quot;&gt;
+              &lt;h4&gt;${esc(t(&#39;flowColSections&#39;))}&lt;span class=&quot;flow-col-count&quot;&gt;${sections.length}&lt;/span&gt;&lt;/h4&gt;
+              &lt;div class=&quot;flow-nodes&quot;&gt;${sectionsHtml}&lt;/div&gt;
+            &lt;/div&gt;
+            &lt;div class=&quot;flow-col flow-col-invariants&quot;&gt;
+              &lt;h4&gt;${esc(t(&#39;flowColInvariants&#39;))}&lt;span class=&quot;flow-col-count&quot;&gt;${invariants.length}&lt;/span&gt;&lt;/h4&gt;
+              &lt;div class=&quot;flow-nodes&quot;&gt;${invariantsHtml}&lt;/div&gt;
+            &lt;/div&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;`;
+  }
+
+  let flowDragState = null;
+
+  function drawFlowWires(doc) {
+    const wrap = document.getElementById(&#39;flow-canvas-wrap&#39;);
+    const wires = document.getElementById(&#39;flow-wires&#39;);
+    const canvas = document.getElementById(&#39;flow-canvas&#39;);
+    if (!wrap || !wires || !canvas) return;
+
+    const coverage = Array.isArray(doc.coverage) ? doc.coverage : [];
+    const invariants = Array.isArray(doc.invariants) ? doc.invariants : [];
+    const sections = Array.isArray(doc.sections) ? doc.sections : [];
+    const knownSectionIds = new Set(sections.map((s) =&gt; s.id));
+
+    const canvasRect = canvas.getBoundingClientRect();
+    wires.setAttribute(&#39;width&#39;,  String(canvasRect.width));
+    wires.setAttribute(&#39;height&#39;, String(canvasRect.height));
+
+    const svgX = (rect) =&gt; rect.left + rect.width / 2 - canvasRect.left;
+    const svgY = (rect) =&gt; rect.top + rect.height / 2 - canvasRect.top;
+    const cssEscape = (s) =&gt; String(s).replace(/[^a-zA-Z0-9_-]/g, (ch) =&gt; `\\${ch}`);
+    const bezier = (x1, y1, x2, y2) =&gt; {
+      const mid = (x1 + x2) / 2;
+      return `M ${x1} ${y1} C ${mid} ${y1}, ${mid} ${y2}, ${x2} ${y2}`;
+    };
+
+    const paths = [];
+
+    // Coverage wires
+    coverage.forEach((edge, idx) =&gt; {
+      const from = canvas.querySelector(`[data-port=&quot;facet-out&quot;][data-facet-id=&quot;${cssEscape(edge.facetId)}&quot;]`);
+      if (!from) return;
+      const drift = !knownSectionIds.has(edge.sectionId);
+      let toX, toY;
+      if (!drift) {
+        const sectionEl = canvas.querySelector(`[data-flow-kind=&quot;section&quot;][data-flow-id=&quot;${cssEscape(edge.sectionId)}&quot;]`);
+        const toPort = sectionEl?.querySelector(&#39;[data-port=&quot;section-in&quot;]&#39;);
+        if (!toPort) return;
+        const r = toPort.getBoundingClientRect();
+        toX = svgX(r); toY = svgY(r);
+      } else {
+        const fr = from.getBoundingClientRect();
+        toX = canvasRect.width * 0.62;
+        toY = svgY(fr);
+      }
+      const fr = from.getBoundingClientRect();
+      const d = bezier(svgX(fr), svgY(fr), toX, toY);
+      paths.push(`&lt;path class=&quot;flow-wire-hit&quot; d=&quot;${d}&quot; data-flow-edge=&quot;coverage&quot; data-flow-edge-index=&quot;${idx}&quot;&gt;&lt;/path&gt;`);
+      paths.push(`&lt;path class=&quot;flow-wire-coverage ${drift ? &#39;flow-wire-drift&#39; : &#39;&#39;}&quot; d=&quot;${d}&quot;/&gt;`);
+    });
+
+    // Invariant arrows — one path per (invariantIdx, appliesToIdx) pair
+    invariants.forEach((inv, invIdx) =&gt; {
+      const from = canvas.querySelector(`[data-port=&quot;inv-out&quot;][data-invariant-id=&quot;${cssEscape(inv.id)}&quot;]`);
+      if (!from) return;
+      const applies = Array.isArray(inv.appliesTo) ? inv.appliesTo : [];
+      const fr = from.getBoundingClientRect();
+      const fromX = svgX(fr), fromY = svgY(fr);
+      applies.forEach((target, targetIdx) =&gt; {
+        let toX, toY;
+        if (target === &#39;*&#39;) {
+          const sectionsCol = canvas.querySelector(&#39;.flow-col-sections&#39;)?.getBoundingClientRect();
+          toX = sectionsCol ? sectionsCol.right - canvasRect.left + 6 : canvasRect.width * 0.62;
+          toY = sectionsCol ? sectionsCol.top - canvasRect.top - 10 : fromY;
+        } else {
+          const sectionEl = canvas.querySelector(`[data-flow-kind=&quot;section&quot;][data-flow-id=&quot;${cssEscape(target)}&quot;]`);
+          const toPort = sectionEl?.querySelector(&#39;[data-port=&quot;section-inv-in&quot;]&#39;);
+          if (!toPort) return;
+          const r = toPort.getBoundingClientRect();
+          toX = svgX(r); toY = svgY(r);
+        }
+        const d = bezier(fromX, fromY, toX, toY);
+        paths.push(`&lt;path class=&quot;flow-wire-hit&quot; d=&quot;${d}&quot; data-flow-edge=&quot;invariant&quot; data-flow-inv-index=&quot;${invIdx}&quot; data-flow-target-index=&quot;${targetIdx}&quot;&gt;&lt;/path&gt;`);
+        paths.push(`&lt;path class=&quot;flow-wire-invariant&quot; d=&quot;${d}&quot; marker-end=&quot;url(#flow-arrow-inv)&quot;/&gt;`);
+      });
+    });
+
+    // Drag preview
+    if (flowDragState) {
+      const portSel = flowDragState.kind === &#39;invariant&#39;
+        ? `[data-port=&quot;inv-out&quot;][data-invariant-id=&quot;${cssEscape(flowDragState.fromId)}&quot;]`
+        : `[data-port=&quot;facet-out&quot;][data-facet-id=&quot;${cssEscape(flowDragState.fromId)}&quot;]`;
+      const from = canvas.querySelector(portSel);
+      if (from) {
+        const fr = from.getBoundingClientRect();
+        const fromX = svgX(fr), fromY = svgY(fr);
+        const toX = flowDragState.mouseX - canvasRect.left;
+        const toY = flowDragState.mouseY - canvasRect.top;
+        const d = bezier(fromX, fromY, toX, toY);
+        const cls = flowDragState.kind === &#39;invariant&#39;
+          ? &#39;flow-wire-invariant flow-wire-preview&#39;
+          : &#39;flow-wire-coverage flow-wire-preview&#39;;
+        const marker = flowDragState.kind === &#39;invariant&#39; ? &#39; marker-end=&quot;url(#flow-arrow-inv)&quot;&#39; : &#39;&#39;;
+        paths.push(`&lt;path class=&quot;${cls}&quot; d=&quot;${d}&quot;${marker}/&gt;`);
+      }
+    }
+
+    const defs = wires.querySelector(&#39;defs&#39;);
+    wires.innerHTML = (defs ? defs.outerHTML : &#39;&#39;) + paths.join(&#39;&#39;);
   }
 
   function renderJsonPreview(json) {
@@ -11548,12 +12493,45 @@ open docs/living-doc-compositor.html&lt;/pre&gt;
           &lt;div class=&quot;guide-layer-body&quot;&gt;
             &lt;p&gt;${esc(t(&#39;guideLayer4Body1&#39;))}&lt;/p&gt;
             &lt;p&gt;${esc(t(&#39;guideLayer4Body2&#39;))}&lt;/p&gt;
+            &lt;p&gt;&lt;em&gt;${esc(t(&#39;guideLayer4FlowIntro&#39;))}&lt;/em&gt;&lt;/p&gt;
 
             &lt;div class=&quot;guide-card-stack&quot;&gt;
-              ${infoCard(t(&#39;guideLayer4FacetsTitle&#39;), t(&#39;guideLayer4FacetsBody&#39;))}
-              ${infoCard(t(&#39;guideLayer4CoverageTitle&#39;), t(&#39;guideLayer4CoverageBody&#39;))}
-              ${infoCard(t(&#39;guideLayer4InvariantsTitle&#39;), t(&#39;guideLayer4InvariantsBody&#39;))}
-              ${infoCard(t(&#39;guideLayer4FingerprintTitle&#39;), t(&#39;guideLayer4FingerprintBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4FacetsTitle&#39;), t(&#39;guideLayer4FacetsBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowFacets&#39;))}&lt;/p&gt;`)}
+              ${infoCard(t(&#39;guideLayer4CoverageTitle&#39;), t(&#39;guideLayer4CoverageBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowCoverage&#39;))}&lt;/p&gt;`)}
+              ${infoCard(t(&#39;guideLayer4InvariantsTitle&#39;), t(&#39;guideLayer4InvariantsBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowInvariants&#39;))}&lt;/p&gt;`)}
+              ${infoCard(t(&#39;guideLayer4FingerprintTitle&#39;), t(&#39;guideLayer4FingerprintBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowFingerprint&#39;))}&lt;/p&gt;`)}
+            &lt;/div&gt;
+
+            &lt;h3&gt;${esc(t(&#39;guideLayer4ReadingTitle&#39;))}&lt;/h3&gt;
+            &lt;p style=&quot;color:var(--muted)&quot;&gt;${esc(t(&#39;guideLayer4ReadingBody&#39;))}&lt;/p&gt;
+            &lt;div class=&quot;guide-card-stack&quot;&gt;
+              ${infoCard(&#39;Columns&#39;, t(&#39;guideLayer4ReadingColumns&#39;))}
+              ${infoCard(&#39;Wires&#39;, t(&#39;guideLayer4ReadingWires&#39;))}
+              ${infoCard(&#39;States&#39;, t(&#39;guideLayer4ReadingStates&#39;))}
+              ${infoCard(&#39;Stats bar&#39;, t(&#39;guideLayer4ReadingStats&#39;))}
+              ${infoCard(&#39;Rationale&#39;, t(&#39;guideLayer4ReadingRationale&#39;))}
+            &lt;/div&gt;
+
+            &lt;h3&gt;${esc(t(&#39;guideLayer4DeepTitle&#39;))}&lt;/h3&gt;
+            &lt;p style=&quot;color:var(--muted)&quot;&gt;${esc(t(&#39;guideLayer4DeepIntro&#39;))}&lt;/p&gt;
+            &lt;div class=&quot;guide-card-stack&quot;&gt;
+              ${infoCard(t(&#39;guideLayer4DeepHashTitle&#39;), t(&#39;guideLayer4DeepHashBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4DeepMomentTitle&#39;), t(&#39;guideLayer4DeepMomentBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4DeepStatesTitle&#39;), t(&#39;guideLayer4DeepStatesBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4DeepRitualsTitle&#39;), t(&#39;guideLayer4DeepRitualsBody&#39;))}
+            &lt;/div&gt;
+            &lt;div class=&quot;guide-accent-callout&quot; style=&quot;margin-top:10px&quot;&gt;
+              &lt;strong&gt;${esc(t(&#39;guideLayer4DeepBridgeTitle&#39;))}&lt;/strong&gt;&lt;br /&gt;
+              &lt;span style=&quot;color:var(--muted);font-size:13.5px&quot;&gt;${esc(t(&#39;guideLayer4DeepBridgeBody&#39;))}&lt;/span&gt;
+            &lt;/div&gt;
+
+            &lt;h3&gt;${esc(t(&#39;guideLayer4EditingTitle&#39;))}&lt;/h3&gt;
+            &lt;p style=&quot;color:var(--muted)&quot;&gt;${esc(t(&#39;guideLayer4EditingBody&#39;))}&lt;/p&gt;
+            &lt;div class=&quot;guide-card-stack&quot;&gt;
+              ${stepCard(1, &#39;Drag a port&#39;, esc(t(&#39;guideLayer4EditingDrag&#39;)))}
+              ${stepCard(2, &#39;Click a wire or chip&#39;, esc(t(&#39;guideLayer4EditingClick&#39;)))}
+              ${stepCard(3, &#39;Delete a node&#39;, esc(t(&#39;guideLayer4EditingRemove&#39;)))}
+              ${stepCard(4, &#39;Reposition and reset&#39;, esc(t(&#39;guideLayer4EditingPosition&#39;)))}
             &lt;/div&gt;
 
             &lt;div class=&quot;guide-accent-callout&quot;&gt;
@@ -13270,7 +14248,7 @@ open docs/living-doc-compositor.html&lt;/pre&gt;
 
     <div class="snapshot-item">
       <span class="snapshot-label">Generated</span>
-      <span class="snapshot-value"><time datetime="2026-04-17T07:34:56.920Z" title="2026-04-17T07:34:56.920Z" data-snapshot-anchor="generated-at" id="snapshot-generated-at">2026-04-17T07:34:56.920Z</time></span>
+      <span class="snapshot-value"><time datetime="2026-04-17T13:00:54.274Z" title="2026-04-17T13:00:54.274Z" data-snapshot-anchor="generated-at" id="snapshot-generated-at">2026-04-17T13:00:54.274Z</time></span>
     </div>
 
     <div class="snapshot-item">
@@ -14063,7 +15041,7 @@ open docs/living-doc-compositor.html&lt;/pre&gt;
     </section>
 
 
-          <p class="footnote" style="margin-top:40px">Living Doc Compositor v0.1.0-5625891 (2026-04-17)</p>
+          <p class="footnote" style="margin-top:40px">Living Doc Compositor v0.1.0-0103671 (2026-04-17)</p>
         </div>
 
     <section id="board-view" class="view-panel board-view" data-view-panel="board" hidden>

--- a/docs/mobile-subscription-refinement-model.html
+++ b/docs/mobile-subscription-refinement-model.html
@@ -1565,7 +1565,208 @@
     background: var(--card); font-size: 12.5px; font-weight: 600; color: var(--muted);
   }
   .preview-tab.active { background: var(--accent); color: #fff; border-color: var(--accent); }
+  .flow-placeholder {
+    margin: 24px; padding: 32px 36px; border-radius: 14px;
+    background: var(--card); border: 1px dashed var(--line);
+    max-width: 720px;
+  }
+  .flow-placeholder-eyebrow {
+    display: inline-block; padding: 3px 10px; border-radius: 999px;
+    background: color-mix(in srgb, var(--accent) 12%, var(--card));
+    color: var(--accent); font-size: 11px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.05em; margin-bottom: 12px;
+  }
+  .flow-placeholder h3 { margin: 0 0 8px; font-size: 18px; letter-spacing: -0.01em; }
+  .flow-placeholder p { margin: 0 0 16px; color: var(--muted); line-height: 1.6; font-size: 13.5px; }
+  .flow-placeholder-summary {
+    padding: 10px 14px; border-radius: 8px;
+    background: color-mix(in srgb, var(--accent) 6%, var(--card));
+    border: 1px solid color-mix(in srgb, var(--accent) 22%, var(--line));
+    font-size: 12.5px; color: var(--ink);
+  }
+  .flow-placeholder-summary-empty {
+    background: color-mix(in srgb, #f59e0b 10%, var(--card));
+    border-color: color-mix(in srgb, #f59e0b 30%, var(--line));
+    color: #92400e;
+  }
+  .flow-view { display: flex; flex-direction: column; min-height: 100%; }
+  .flow-stats {
+    display: flex; gap: 6px; padding: 10px 16px;
+    border-bottom: 1px solid var(--line); background: var(--card);
+    flex-wrap: wrap; position: sticky; top: 0; z-index: 2;
+  }
+  .flow-stat {
+    display: inline-flex; gap: 6px; padding: 4px 10px; border-radius: 999px;
+    background: var(--bg); border: 1px solid var(--line); font-size: 12px;
+  }
+  .flow-stat strong { color: var(--ink); font-weight: 700; }
+  .flow-stat-warn { background: #fffbeb; color: #92400e; border-color: #fde68a; }
+  .flow-stat-bad { background: #fef2f2; color: #991b1b; border-color: #fecaca; }
+  .flow-canvas-wrap {
+    position: relative; flex: 1; overflow: auto; background: var(--bg);
+    min-height: 420px;
+  }
+  .flow-canvas {
+    position: relative; display: grid;
+    grid-template-columns: 260px 260px 260px;
+    gap: 72px; padding: 24px 28px 48px;
+    min-width: 924px;
+    justify-content: start;
+  }
+  .flow-col h4 {
+    margin: 0 0 10px; font-size: 11px; font-weight: 700;
+    text-transform: uppercase; letter-spacing: 0.06em; color: var(--muted);
+  }
+  .flow-col h4 .flow-col-count {
+    margin-left: 6px; padding: 1px 8px; border-radius: 999px;
+    background: var(--card); border: 1px solid var(--line);
+    color: var(--muted); font-size: 10px; font-weight: 700;
+  }
+  .flow-nodes { display: flex; flex-direction: column; gap: 10px; }
+  .flow-node {
+    position: relative; padding: 10px 12px 10px 14px;
+    background: var(--card); border: 1px solid var(--line); border-radius: 10px;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  }
+  .flow-node-header {
+    display: flex; gap: 6px; align-items: baseline; flex-wrap: wrap;
+  }
+  .flow-node-header h5 { margin: 0; font-size: 13px; font-weight: 700; }
+  .flow-node-id {
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 10.5px; color: var(--muted);
+  }
+  .flow-node-body { margin-top: 4px; font-size: 12px; color: var(--muted); line-height: 1.5; }
+  .flow-badge {
+    display: inline-flex; padding: 1px 8px; border-radius: 999px;
+    font-size: 10px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flow-badge-ct { background: #ecfeff; color: #155e75; margin-left: auto; }
+  .flow-badge-orphan { background: #fef2f2; color: #991b1b; }
+  .flow-badge-docwide { background: #fef3c7; color: #92400e; margin-left: auto; cursor: pointer; border: 1px solid #fde68a; transition: background 0.15s, border-color 0.15s; }
+  .flow-badge-docwide:hover { background: #fde68a; border-color: #f59e0b; }
+  .flow-badge-docwide.flow-badge-docwide-active { background: #d97706; color: #fff; border-color: #d97706; }
+  .flow-badge-docwide.flow-badge-docwide-active:hover { background: #b45309; border-color: #b45309; }
+  .flow-node-orphan {
+    background: color-mix(in srgb, #fef2f2 40%, var(--card));
+    border-color: #fecaca;
+  }
+  .flow-card-chips { display: flex; flex-wrap: wrap; gap: 3px; margin-top: 6px; }
+  .flow-card-chip {
+    display: inline-flex; padding: 1px 7px; border-radius: 5px;
+    background: var(--bg); border: 1px solid var(--line);
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    font-size: 10px; color: var(--muted);
+  }
+  .flow-rationale {
+    margin-top: 8px; padding: 6px 9px; border-radius: 7px;
+    background: var(--bg); border: 1px dashed var(--line);
+    font-size: 11.5px; font-style: italic; color: var(--muted); line-height: 1.5;
+  }
+  .flow-rationale-empty {
+    color: color-mix(in srgb, var(--muted) 55%, var(--card));
+    border-style: dotted;
+  }
+  .flow-invariant {
+    background: color-mix(in srgb, #fffbeb 45%, var(--card));
+    border-color: #fde68a;
+  }
+  .flow-invariant-statement {
+    margin-top: 5px; font-size: 11.5px; color: #78350f; line-height: 1.5;
+  }
+  .flow-port {
+    position: absolute; top: 50%; transform: translateY(-50%);
+    width: 10px; height: 10px; border-radius: 50%;
+    background: var(--card); border: 2px solid #94a3b8; z-index: 3;
+  }
+  .flow-port-out { right: -7px; }
+  .flow-port-in-left { left: -7px; }
+  .flow-port-in-right { right: -7px; border-color: #d97706; }
+  .flow-port-inv-out { left: -7px; border-color: #d97706; }
+  .flow-wires {
+    position: absolute; inset: 0; width: 100%; height: 100%;
+    pointer-events: none; z-index: 1;
+  }
+  .flow-wires path { fill: none; }
+  .flow-wires path.flow-wire-coverage, .flow-wires path.flow-wire-invariant { pointer-events: none; }
+  .flow-wire-coverage { stroke: #94a3b8; stroke-width: 2; }
+  .flow-wire-coverage.flow-wire-drift { stroke: #b91c1c; stroke-dasharray: 4 4; }
+  .flow-wire-invariant { stroke: #d97706; stroke-width: 2; }
+  .flow-wire-hit { stroke: transparent; stroke-width: 16; pointer-events: stroke; cursor: pointer; }
+  .flow-wire-preview { stroke-dasharray: 6 4; opacity: 0.8; pointer-events: none; }
+  .flow-port { cursor: crosshair; transition: transform 0.12s, background 0.15s, border-color 0.15s; }
+  .flow-port:hover { transform: translateY(-50%) scale(1.35); background: var(--accent); border-color: var(--accent); }
+  .flow-port-in-right:hover, .flow-port-inv-out:hover { background: #d97706; border-color: #d97706; }
+  .flow-port.flow-port-dragging { background: var(--accent); border-color: var(--accent); }
+  .flow-port.flow-port-dragging-inv { background: #d97706; border-color: #d97706; }
+  .flow-remove {
+    position: absolute; top: 6px; right: 6px;
+    width: 20px; height: 20px; border-radius: 50%;
+    border: 1px solid var(--line); background: var(--card);
+    color: var(--muted); font-size: 13px; line-height: 1;
+    cursor: pointer; opacity: 0; transition: opacity 0.15s;
+    display: inline-flex; align-items: center; justify-content: center;
+    padding: 0;
+  }
+  .flow-node:hover .flow-remove { opacity: 1; }
+  .flow-remove:hover { background: #fef2f2; color: #991b1b; border-color: #991b1b; }
+  .flow-rationale { cursor: pointer; transition: border-color 0.15s, color 0.15s; }
+  .flow-rationale:hover { border-color: var(--accent); color: var(--ink); }
+  .flow-banner {
+    display: none; gap: 14px; align-items: center; flex-wrap: wrap;
+    padding: 12px 16px; border-bottom: 1px solid var(--line);
+    background: var(--card); font-size: 13px; line-height: 1.5;
+  }
+  .flow-banner[data-state=&quot;missing&quot;] {
+    display: flex; background: var(--neutral-bg); color: var(--neutral-ink);
+    border-bottom-color: var(--line);
+  }
+  .flow-banner[data-state=&quot;stale&quot;] {
+    display: flex;
+    background: color-mix(in srgb, #fffbeb 65%, var(--card));
+    color: #92400e;
+    border-bottom-color: #fde68a;
+  }
+  .flow-banner strong { font-weight: 700; }
+  .flow-banner-body { flex: 1; min-width: 200px; }
+  .flow-banner-actions { display: flex; gap: 6px; flex-wrap: wrap; }
+  .flow-banner-btn {
+    padding: 5px 12px; font: inherit; font-size: 12px; font-weight: 600;
+    border: 1px solid var(--line); background: var(--card); border-radius: 7px;
+    color: var(--ink); cursor: pointer;
+  }
+  .flow-banner-btn:hover { border-color: var(--accent); color: var(--accent); }
+  .flow-banner-btn-primary { background: #d97706; color: #fff; border-color: #d97706; }
+  .flow-banner-btn-primary:hover { background: #b45309; border-color: #b45309; color: #fff; }
+  .flow-canvas-wrap.flow-stale .flow-wire-coverage,
+  .flow-canvas-wrap.flow-stale .flow-wire-invariant {
+    opacity: 0.4; filter: saturate(0.6);
+  }
+  .flow-canvas-wrap.flow-stale .flow-wire-coverage.flow-wire-drift { opacity: 0.5; }
+  .flow-node { cursor: grab; }
+  .flow-node:active { cursor: grabbing; }
+  .flow-node .flow-port,
+  .flow-node .flow-remove,
+  .flow-node .flow-badge-docwide,
+  .flow-node .flow-rationale { cursor: pointer; }
+  .flow-node[data-flow-positioned=&quot;true&quot;] { position: absolute; z-index: 2; width: 260px; }
+  .flow-node.flow-node-dragging { opacity: 0.85; box-shadow: 0 4px 14px rgba(0,0,0,0.12); cursor: grabbing; z-index: 3; user-select: none; }
+  .flow-node.flow-node-dragging * { user-select: none; }
+  .flow-node .flow-node-header h5 { user-select: none; }
+  .flow-reset-layout-btn {
+    margin-left: auto; padding: 4px 10px; font: inherit; font-size: 12px; font-weight: 600;
+    border: 1px solid var(--line); background: var(--card); border-radius: 7px;
+    color: var(--muted); cursor: pointer;
+  }
+  .flow-reset-layout-btn:hover { border-color: var(--accent); color: var(--accent); }
+  .flow-empty {
+    margin: 24px; padding: 32px 36px; border-radius: 14px;
+    background: var(--card); border: 1px dashed var(--line);
+    max-width: 720px; color: var(--muted); font-size: 13.5px; line-height: 1.6;
+  }
+  .flow-empty strong { color: var(--ink); display: block; margin-bottom: 8px; font-size: 15px; }
   .preview-content { padding: 24px; scroll-behavior: smooth; }
+  .preview-content.preview-content-flow { padding: 0; display: flex; flex-direction: column; }
   .preview-iframe { width: 100%; border: none; border-radius: var(--radius); background: #fff; min-height: calc(100vh - 80px); }
   .doc-editor-card {
     margin-bottom: 18px; padding: 20px; border-radius: 14px;
@@ -2422,7 +2623,26 @@
       &quot;preview&quot;: &quot;Preview&quot;,
       &quot;visual&quot;: &quot;Visual&quot;,
       &quot;board&quot;: &quot;Board&quot;,
+      &quot;flow&quot;: &quot;Flow&quot;,
       &quot;json&quot;: &quot;JSON&quot;,
+      &quot;flowEmptyTitle&quot;: &quot;Governance canvas&quot;,
+      &quot;flowEmptyBody&quot;: &quot;The Flow view renders the doc&#39;s governance layer — objective facets, coverage edges, invariants, and rationale — as a canvas. Canvas rendering lands in #47. Tab is in place; data-flow wiring follows.&quot;,
+      &quot;flowMissingGovernance&quot;: &quot;This doc has no governance data yet. Run /crystallize on the JSON to populate objectiveFacets, coverage, and invariants.&quot;,
+      &quot;flowColFacets&quot;: &quot;Objective facets&quot;,
+      &quot;flowColSections&quot;: &quot;Sections&quot;,
+      &quot;flowColInvariants&quot;: &quot;Invariants&quot;,
+      &quot;flowMetaChecking&quot;: &quot;Checking meta freshness…&quot;,
+      &quot;flowMetaCheckingBody&quot;: &quot;Computing the current section fingerprint.&quot;,
+      &quot;flowMetaMissingTitle&quot;: &quot;Meta not yet stamped.&quot;,
+      &quot;flowMetaMissingBody&quot;: &quot;Run /crystallize to seed objectiveFacets, coverage, invariants, and a metaFingerprint so drift becomes detectable.&quot;,
+      &quot;flowMetaStaleTitle&quot;: &quot;Meta is stale.&quot;,
+      &quot;flowMetaStaleBody&quot;: &quot;Sections have changed since the meta was derived. Coverage edges may point at the wrong cards. Run /crystallize --refresh or stamp a new fingerprint.&quot;,
+      &quot;flowStampNow&quot;: &quot;Stamp fingerprint now&quot;,
+      &quot;flowStamping&quot;: &quot;Stamping…&quot;,
+      &quot;flowStamped&quot;: &quot;Stamped&quot;,
+      &quot;flowCrystallize&quot;: &quot;Copy /crystallize prompt&quot;,
+      &quot;flowCrystallizeCopied&quot;: &quot;Copied&quot;,
+      &quot;flowResetLayout&quot;: &quot;Reset layout&quot;,
       &quot;templates&quot;: &quot;Templates&quot;,
       &quot;templatesHint&quot;: &quot;Browse starter and advanced living doc templates&quot;,
       &quot;templatesIntro&quot;: &quot;Start with a simple starter template or jump straight into a fuller advanced shape.&quot;,
@@ -2558,7 +2778,37 @@
       &quot;guideLayer4FingerprintTitle&quot;: &quot;Fingerprint and freshness&quot;,
       &quot;guideLayer4FingerprintBody&quot;: &quot;A sha256 of the section structure at crystallization time. Renders as a banner when the sections have moved but the meta has not — stale coverage is worse than no coverage, so drift becomes loud.&quot;,
       &quot;guideLayer4CrystallizeTitle&quot;: &quot;Second-pass refinement, not an authoring gate&quot;,
-      &quot;guideLayer4CrystallizeBody&quot;: &quot;Don&#39;t crystallize early iteration — facets haven&#39;t settled. Run `/crystallize &lt;doc&gt;` once the shape is stable; the skill proposes facets, coverage, invariants, and rationale from what the doc already contains. Re-run with `--refresh` on structural change.&quot;,
+      &quot;guideLayer4CrystallizeBody&quot;: &quot;Don&#39;t crystallize early iteration — facets haven&#39;t settled. Run `/crystallize &lt;doc&gt;` once the shape is stable; the skill proposes facets, coverage, invariants, and rationale from what the doc already contains. Re-run with `--refresh` on structural change. Open the Flow tab to watch the facets and coverage populate as the skill writes them.&quot;,
+      &quot;guideLayer4FlowIntro&quot;: &quot;The Flow tab in the compositor is the primary surface for governance. Open a crystallized doc, switch to Flow, and the layer becomes a canvas: facets on the left, sections in the middle, invariants on the right, with typed wires between them.&quot;,
+      &quot;guideLayer4FlowFacets&quot;: &quot;In the Flow canvas: the left column. Orphan facets render as pink cards with an Orphan badge, so gaps in the coverage are visible at a glance. Drag a facet&#39;s right port to a section&#39;s left port to add a coverage edge.&quot;,
+      &quot;guideLayer4FlowCoverage&quot;: &quot;In the Flow canvas: gray bezier wires from each facet&#39;s right port to the section&#39;s left port. Drift (the target section has been removed) renders as a dashed red wire trailing off toward the sections column. Click a wire to remove it.&quot;,
+      &quot;guideLayer4FlowInvariants&quot;: &quot;In the Flow canvas: the right column, amber arrows with arrowheads point at the sections they govern. Click the Doc-wide chip on an invariant to toggle `appliesTo: [\&quot;*\&quot;]`; the arrows collapse into one arrow pointing at a virtual anchor above the sections column. Drag to a specific section to rescope.&quot;,
+      &quot;guideLayer4FlowFingerprint&quot;: &quot;In the Flow canvas: an amber banner pins at the top when the fingerprint is stale. Coverage and invariant wires dim and desaturate so the stale state is unmistakable. The banner&#39;s Stamp button re-computes and stores the new fingerprint; the Crystallize button copies `/crystallize &lt;doc&gt; --refresh` to the clipboard.&quot;,
+      &quot;guideLayer4ReadingTitle&quot;: &quot;Reading the Flow canvas&quot;,
+      &quot;guideLayer4ReadingBody&quot;: &quot;Three columns, three roles. Two wire colors, two node states. One italicized footer per section.&quot;,
+      &quot;guideLayer4ReadingColumns&quot;: &quot;Columns · Objective facets (left) → sections (middle) → invariants (right). Each is a governance role expressed as a column.&quot;,
+      &quot;guideLayer4ReadingWires&quot;: &quot;Wires · Gray bezier = coverage (facet is carried by section). Amber bezier with arrowhead = invariant (rule governs section). Dashed variants signal drift or in-flight preview.&quot;,
+      &quot;guideLayer4ReadingStates&quot;: &quot;States · Pink facet card + Orphan badge = no coverage edges. Dashed red wire = drifted (points at a missing section). Dimmed + desaturated wires = metaFingerprint is stale.&quot;,
+      &quot;guideLayer4ReadingStats&quot;: &quot;Stats bar · Pinned at the top: facet / section / coverage / invariant counts, rationale declared vs total, and loud pills for orphan or drift counts when either is non-zero.&quot;,
+      &quot;guideLayer4ReadingRationale&quot;: &quot;Rationale · Italicized dashed card at the bottom of each section node. A dotted \&quot;no rationale declared yet\&quot; stub appears when the field is missing so authoring gaps stay visible.&quot;,
+      &quot;guideLayer4EditingTitle&quot;: &quot;Editing via the Flow canvas&quot;,
+      &quot;guideLayer4EditingBody&quot;: &quot;Every interaction writes to the same `docExtras` that `/crystallize` and the tabular editor use, so the canvas stays in sync with the other views.&quot;,
+      &quot;guideLayer4EditingDrag&quot;: &quot;Drag a port → create a wire. Facet out-port to section in-port adds coverage (picks an unused cardId from the section). Invariant out-port to section right-port adds that section to `appliesTo`, stripping any existing `\&quot;*\&quot;`.&quot;,
+      &quot;guideLayer4EditingClick&quot;: &quot;Click a wire → remove it. Click the Doc-wide chip on an invariant → toggle doc-wide scope. Click a section&#39;s rationale card → edit the sentence inline via prompt.&quot;,
+      &quot;guideLayer4EditingRemove&quot;: &quot;× on hover → delete a node. Facets cascade their coverage; sections intentionally leave coverage edges behind as drift (the visual signal stays visible); invariants are a clean delete.&quot;,
+      &quot;guideLayer4EditingPosition&quot;: &quot;Drag a node body → reposition on the canvas (`flowPosition` saves to the node). Double-click → return to column. Reset layout button in the stats bar → clear all custom positions.&quot;,
+      &quot;guideLayer4DeepTitle&quot;: &quot;Fingerprint, freshness, and the crystallization moment&quot;,
+      &quot;guideLayer4DeepIntro&quot;: &quot;The fingerprint is cheap to compute and load-bearing. Understanding what it hashes, when to stamp it, and what freshness means turns governance from a static label into a living contract.&quot;,
+      &quot;guideLayer4DeepHashTitle&quot;: &quot;What the fingerprint hashes&quot;,
+      &quot;guideLayer4DeepHashBody&quot;: &quot;A sha256 of each section&#39;s id, convergenceType, and ordered card ids. Stable under prose edits within cards; unstable when sections are added or removed, renamed, or restructured. The choice is deliberate — governance maps to structure, not to content.&quot;,
+      &quot;guideLayer4DeepMomentTitle&quot;: &quot;The crystallization moment&quot;,
+      &quot;guideLayer4DeepMomentBody&quot;: &quot;Think of it as a git commit on the doc&#39;s meaning. Before the stamp, the doc is in shape-discovery mode and governance would calcify bad decompositions. After the stamp, governance pins to an exact structural state. Crystallize when the shape is stable enough that a week of small edits won&#39;t reshape it.&quot;,
+      &quot;guideLayer4DeepStatesTitle&quot;: &quot;Three states, three postures&quot;,
+      &quot;guideLayer4DeepStatesBody&quot;: &quot;Missing — no fingerprint, nothing to check; agents fall back to prose re-derivation. Fresh — stored matches current; agents deterministically target the right cards via coverage edges. Stale — stored differs from current; wires dim and agents must fall back to prose, because coverage may now point at cards whose meaning has shifted.&quot;,
+      &quot;guideLayer4DeepRitualsTitle&quot;: &quot;Stamp vs refresh&quot;,
+      &quot;guideLayer4DeepRitualsBody&quot;: &quot;Stamp (from the Flow banner) — recompute the sha256 and store it. Preserves existing facets, coverage, invariants, and rationale. Use when the structural edit is semantic-neutral (renamed a section you just added, reshuffled a card id). Refresh via `/crystallize &lt;doc&gt; --refresh` — rerun the skill. Proposes updated facets and coverage for the new structure; preserves author-edited fields. Use when the change is genuinely new shape.&quot;,
+      &quot;guideLayer4DeepBridgeTitle&quot;: &quot;Why this bridges authoring and long-term coherence&quot;,
+      &quot;guideLayer4DeepBridgeBody&quot;: &quot;Without a fingerprint, \&quot;is this doc still coherent?\&quot; requires an LLM re-read and human judgment on every pass. With a fingerprint, it&#39;s a hash comparison. That collapse — from judgment to verification — is what turns a living doc from an opinionated structure into a testable substrate. Over time it enables empirical evaluation of which doc shapes actually perform well for human and agent readers alike.&quot;,
       &quot;guideLayer5Title&quot;: &quot;Extending the Vocabulary&quot;,
       &quot;guideLayer5Tagline&quot;: &quot;Creating a new convergence type when nothing fits.&quot;,
       &quot;guideLayer6Title&quot;: &quot;Working with Living Docs&quot;,
@@ -2693,7 +2943,26 @@
       &quot;preview&quot;: &quot;Voorbeeld&quot;,
       &quot;visual&quot;: &quot;Visueel&quot;,
       &quot;board&quot;: &quot;Bord&quot;,
+      &quot;flow&quot;: &quot;Flow&quot;,
       &quot;json&quot;: &quot;JSON&quot;,
+      &quot;flowEmptyTitle&quot;: &quot;Governance-canvas&quot;,
+      &quot;flowEmptyBody&quot;: &quot;De Flow-weergave rendert de governance-laag van het document — doelfacetten, coverage-edges, invarianten en rationale — als canvas. Canvasrendering landt in #47. Het tabblad staat; datastromen volgen.&quot;,
+      &quot;flowMissingGovernance&quot;: &quot;Dit document heeft nog geen governance-data. Draai /crystallize op de JSON om objectiveFacets, coverage en invariants te vullen.&quot;,
+      &quot;flowColFacets&quot;: &quot;Doelfacetten&quot;,
+      &quot;flowColSections&quot;: &quot;Secties&quot;,
+      &quot;flowColInvariants&quot;: &quot;Invarianten&quot;,
+      &quot;flowMetaChecking&quot;: &quot;Versheid van meta controleren…&quot;,
+      &quot;flowMetaCheckingBody&quot;: &quot;Huidige sectievingerafdruk berekenen.&quot;,
+      &quot;flowMetaMissingTitle&quot;: &quot;Meta nog niet gestempeld.&quot;,
+      &quot;flowMetaMissingBody&quot;: &quot;Draai /crystallize om objectiveFacets, coverage, invariants en een metaFingerprint te zaaien zodat drift detecteerbaar wordt.&quot;,
+      &quot;flowMetaStaleTitle&quot;: &quot;Meta is verouderd.&quot;,
+      &quot;flowMetaStaleBody&quot;: &quot;Secties zijn gewijzigd sinds de meta werd afgeleid. Coverage-edges kunnen naar verkeerde kaarten wijzen. Draai /crystallize --refresh of stempel een nieuwe vingerafdruk.&quot;,
+      &quot;flowStampNow&quot;: &quot;Vingerafdruk nu stempelen&quot;,
+      &quot;flowStamping&quot;: &quot;Stempelen…&quot;,
+      &quot;flowStamped&quot;: &quot;Gestempeld&quot;,
+      &quot;flowCrystallize&quot;: &quot;Kopieer /crystallize-prompt&quot;,
+      &quot;flowCrystallizeCopied&quot;: &quot;Gekopieerd&quot;,
+      &quot;flowResetLayout&quot;: &quot;Layout resetten&quot;,
       &quot;templates&quot;: &quot;Templates&quot;,
       &quot;templatesHint&quot;: &quot;Blader door starter- en geavanceerde living-doc-templates&quot;,
       &quot;templatesIntro&quot;: &quot;Begin met een eenvoudige starter-template of spring direct naar een uitgebreidere geavanceerde vorm.&quot;,
@@ -3000,7 +3269,37 @@
       &quot;guideLayer4FingerprintTitle&quot;: &quot;Vingerafdruk en versheid&quot;,
       &quot;guideLayer4FingerprintBody&quot;: &quot;Een sha256 van de sectiestructuur op het moment van uitkristalliseren. Toont een banner wanneer secties zijn verschoven maar de meta niet — verouderde coverage is erger dan geen coverage, dus drift wordt luid.&quot;,
       &quot;guideLayer4CrystallizeTitle&quot;: &quot;Tweede-pass verfijning, geen authoring-gate&quot;,
-      &quot;guideLayer4CrystallizeBody&quot;: &quot;Kristalliseer niet in vroege iteratie — facetten zijn nog niet uitgekristalliseerd. Draai `/crystallize &lt;doc&gt;` zodra de vorm stabiel is; de skill stelt facetten, coverage, invarianten en rationale voor vanuit wat het document al bevat. Herhaal met `--refresh` bij structurele wijziging.&quot;,
+      &quot;guideLayer4CrystallizeBody&quot;: &quot;Kristalliseer niet in vroege iteratie — facetten zijn nog niet uitgekristalliseerd. Draai `/crystallize &lt;doc&gt;` zodra de vorm stabiel is; de skill stelt facetten, coverage, invarianten en rationale voor vanuit wat het document al bevat. Herhaal met `--refresh` bij structurele wijziging. Open het Flow-tabblad om facetten en coverage te zien verschijnen terwijl de skill ze wegschrijft.&quot;,
+      &quot;guideLayer4FlowIntro&quot;: &quot;Het Flow-tabblad in de compositor is het primaire oppervlak voor governance. Open een gekristalliseerd document, schakel over naar Flow, en de laag wordt een canvas: facetten links, secties in het midden, invarianten rechts, met getypeerde draden ertussen.&quot;,
+      &quot;guideLayer4FlowFacets&quot;: &quot;In het Flow-canvas: de linkerkolom. Orphan-facetten verschijnen als roze kaarten met een Orphan-badge, zodat gaten in de coverage in één oogopslag zichtbaar zijn. Sleep de rechterpoort van een facet naar de linkerpoort van een sectie om een coverage-edge toe te voegen.&quot;,
+      &quot;guideLayer4FlowCoverage&quot;: &quot;In het Flow-canvas: grijze bezier-draden van de rechterpoort van elk facet naar de linkerpoort van de sectie. Drift (de doelsectie is verwijderd) verschijnt als een gestreepte rode draad die richting de sectiekolom wegloopt. Klik op een draad om hem te verwijderen.&quot;,
+      &quot;guideLayer4FlowInvariants&quot;: &quot;In het Flow-canvas: de rechterkolom, amberen pijlen met pijlpunten wijzen naar de secties die ze beheren. Klik op de Doc-wide-chip van een invariant om `appliesTo: [\&quot;*\&quot;]` om te schakelen; de pijlen klappen samen in één pijl die wijst naar een virtueel anker boven de sectiekolom. Sleep naar een specifieke sectie om opnieuw te scopen.&quot;,
+      &quot;guideLayer4FlowFingerprint&quot;: &quot;In het Flow-canvas: een amberen banner blijft bovenaan hangen wanneer de vingerafdruk verouderd is. Coverage- en invariant-draden vervagen en desatureren zodat de verouderde staat onmiskenbaar is. De Stempel-knop in de banner herberekent en slaat een nieuwe vingerafdruk op; de Kristalliseer-knop kopieert `/crystallize &lt;doc&gt; --refresh` naar het klembord.&quot;,
+      &quot;guideLayer4ReadingTitle&quot;: &quot;Het Flow-canvas lezen&quot;,
+      &quot;guideLayer4ReadingBody&quot;: &quot;Drie kolommen, drie rollen. Twee draadkleuren, twee knooppunttoestanden. Eén cursieve voettekst per sectie.&quot;,
+      &quot;guideLayer4ReadingColumns&quot;: &quot;Kolommen · Doelfacetten (links) → secties (midden) → invarianten (rechts). Elk is een governance-rol uitgedrukt als kolom.&quot;,
+      &quot;guideLayer4ReadingWires&quot;: &quot;Draden · Grijze bezier = coverage (facet wordt gedragen door sectie). Amberen bezier met pijlpunt = invariant (regel beheert sectie). Gestreepte varianten signaleren drift of in-uitvoering-preview.&quot;,
+      &quot;guideLayer4ReadingStates&quot;: &quot;Toestanden · Roze facetkaart + Orphan-badge = geen coverage-edges. Gestreepte rode draad = gedriftet (wijst naar een ontbrekende sectie). Vervaagde + gedesatureerde draden = metaFingerprint is verouderd.&quot;,
+      &quot;guideLayer4ReadingStats&quot;: &quot;Statusbalk · Vastgeprikt bovenaan: facet / sectie / coverage / invariant-aantallen, aangegeven rationale versus totaal, en opvallende labels voor orphan- of drift-aantallen wanneer die niet nul zijn.&quot;,
+      &quot;guideLayer4ReadingRationale&quot;: &quot;Rationale · Cursieve gestippelde kaart onderaan elk sectieknooppunt. Een gestippelde \&quot;nog geen rationale verklaard\&quot;-stub verschijnt wanneer het veld ontbreekt, zodat hiaten in authoring zichtbaar blijven.&quot;,
+      &quot;guideLayer4EditingTitle&quot;: &quot;Bewerken via het Flow-canvas&quot;,
+      &quot;guideLayer4EditingBody&quot;: &quot;Elke interactie schrijft naar dezelfde `docExtras` die `/crystallize` en de tabulaire editor gebruiken, zodat het canvas synchroon blijft met de andere weergaven.&quot;,
+      &quot;guideLayer4EditingDrag&quot;: &quot;Sleep een poort → maak een draad. Facet-uitpoort naar sectie-inpoort voegt coverage toe (kiest een ongebruikte cardId uit de sectie). Invariant-uitpoort naar sectie-rechterpoort voegt die sectie toe aan `appliesTo`, waarbij een bestaande `\&quot;*\&quot;` wordt verwijderd.&quot;,
+      &quot;guideLayer4EditingClick&quot;: &quot;Klik op een draad → verwijder hem. Klik op de Doc-wide-chip van een invariant → schakel doc-brede scope om. Klik op de rationale-kaart van een sectie → bewerk de zin inline via prompt.&quot;,
+      &quot;guideLayer4EditingRemove&quot;: &quot;× bij hover → verwijder een knooppunt. Facetten cascaderen hun coverage; secties laten coverage-edges opzettelijk achter als drift (het visuele signaal blijft zichtbaar); invarianten zijn een schone verwijdering.&quot;,
+      &quot;guideLayer4EditingPosition&quot;: &quot;Sleep een knooppunt-body → verplaatsen op het canvas (`flowPosition` wordt opgeslagen op het knooppunt). Dubbelklik → terug naar kolom. Layout-reset-knop in de statusbalk → wis alle aangepaste posities.&quot;,
+      &quot;guideLayer4DeepTitle&quot;: &quot;Vingerafdruk, versheid en het kristallisatiemoment&quot;,
+      &quot;guideLayer4DeepIntro&quot;: &quot;De vingerafdruk is goedkoop te berekenen en draagt veel gewicht. Begrijpen wat hij hasht, wanneer je hem stempelt en wat versheid betekent, verandert governance van een statisch etiket in een levend contract.&quot;,
+      &quot;guideLayer4DeepHashTitle&quot;: &quot;Wat de vingerafdruk hasht&quot;,
+      &quot;guideLayer4DeepHashBody&quot;: &quot;Een sha256 van elk sectie-id, convergenceType en de geordende kaart-id&#39;s. Stabiel onder proza-bewerkingen binnen kaarten; instabiel wanneer secties worden toegevoegd of verwijderd, hernoemd of geherstructureerd. De keuze is opzettelijk — governance volgt structuur, geen inhoud.&quot;,
+      &quot;guideLayer4DeepMomentTitle&quot;: &quot;Het kristallisatiemoment&quot;,
+      &quot;guideLayer4DeepMomentBody&quot;: &quot;Beschouw het als een git-commit op de betekenis van het document. Vóór de stempel is het document in vormontdekking en zou governance slechte decomposities uitkristalliseren. Na de stempel is governance vastgepind op een exacte structurele staat. Kristalliseer wanneer de vorm stabiel genoeg is dat een week van kleine bewerkingen hem niet opnieuw vormt.&quot;,
+      &quot;guideLayer4DeepStatesTitle&quot;: &quot;Drie toestanden, drie houdingen&quot;,
+      &quot;guideLayer4DeepStatesBody&quot;: &quot;Ontbrekend — geen vingerafdruk, niets om te controleren; agents vallen terug op proza-herafleiding. Vers — opgeslagen komt overeen met huidig; agents richten deterministisch op de juiste kaarten via coverage-edges. Verouderd — opgeslagen verschilt van huidig; draden vervagen en agents moeten terugvallen op proza omdat coverage naar kaarten kan wijzen waarvan de betekenis is verschoven.&quot;,
+      &quot;guideLayer4DeepRitualsTitle&quot;: &quot;Stempelen vs verversen&quot;,
+      &quot;guideLayer4DeepRitualsBody&quot;: &quot;Stempelen (vanuit de Flow-banner) — bereken de sha256 opnieuw en sla hem op. Behoudt bestaande facetten, coverage, invarianten en rationale. Gebruik wanneer de structurele bewerking semantisch-neutraal is (een sectie die je net toevoegde hernoemd, een kaart-id hergeschikt). Verversen via `/crystallize &lt;doc&gt; --refresh` — draai de skill opnieuw. Stelt bijgewerkte facetten en coverage voor voor de nieuwe structuur; behoudt door auteur bewerkte velden. Gebruik wanneer de wijziging werkelijk nieuwe vorm is.&quot;,
+      &quot;guideLayer4DeepBridgeTitle&quot;: &quot;Waarom dit authoring en langdurige coherentie verbindt&quot;,
+      &quot;guideLayer4DeepBridgeBody&quot;: &quot;Zonder vingerafdruk vereist \&quot;is dit document nog coherent?\&quot; bij elke iteratie een LLM-herleest en menselijk oordeel. Met een vingerafdruk is het een hash-vergelijking. Die ineenstorting — van oordeel naar verificatie — is wat een living doc verandert van een eigengereide structuur in een toetsbaar substraat. In de loop van de tijd maakt het empirische evaluatie mogelijk van welke documentvormen daadwerkelijk goed presteren voor zowel mens als agent.&quot;,
       &quot;guideLayer5Title&quot;: &quot;De Woordenschat Uitbreiden&quot;,
       &quot;guideLayer5Tagline&quot;: &quot;Een nieuw convergentietype maken wanneer niets past.&quot;,
       &quot;guideLayer6Title&quot;: &quot;Werken met Living Docs&quot;,
@@ -3135,7 +3434,26 @@
       &quot;preview&quot;: &quot;Pratinjau&quot;,
       &quot;visual&quot;: &quot;Visual&quot;,
       &quot;board&quot;: &quot;Papan&quot;,
+      &quot;flow&quot;: &quot;Flow&quot;,
       &quot;json&quot;: &quot;JSON&quot;,
+      &quot;flowEmptyTitle&quot;: &quot;Kanvas governance&quot;,
+      &quot;flowEmptyBody&quot;: &quot;Tampilan Flow merender lapisan governance dokumen — faset tujuan, edge coverage, invarian, dan rationale — sebagai kanvas. Rendering kanvas mendarat di #47. Tab sudah ada; aliran data menyusul.&quot;,
+      &quot;flowMissingGovernance&quot;: &quot;Dokumen ini belum memiliki data governance. Jalankan /crystallize pada JSON untuk mengisi objectiveFacets, coverage, dan invariants.&quot;,
+      &quot;flowColFacets&quot;: &quot;Faset tujuan&quot;,
+      &quot;flowColSections&quot;: &quot;Seksi&quot;,
+      &quot;flowColInvariants&quot;: &quot;Invarian&quot;,
+      &quot;flowMetaChecking&quot;: &quot;Memeriksa kesegaran meta…&quot;,
+      &quot;flowMetaCheckingBody&quot;: &quot;Menghitung sidik jari seksi saat ini.&quot;,
+      &quot;flowMetaMissingTitle&quot;: &quot;Meta belum disegel.&quot;,
+      &quot;flowMetaMissingBody&quot;: &quot;Jalankan /crystallize untuk menanam objectiveFacets, coverage, invariants, dan metaFingerprint agar drift dapat dideteksi.&quot;,
+      &quot;flowMetaStaleTitle&quot;: &quot;Meta basi.&quot;,
+      &quot;flowMetaStaleBody&quot;: &quot;Seksi berubah sejak meta diturunkan. Edge coverage mungkin menunjuk ke kartu yang salah. Jalankan /crystallize --refresh atau segel sidik jari baru.&quot;,
+      &quot;flowStampNow&quot;: &quot;Segel sidik jari sekarang&quot;,
+      &quot;flowStamping&quot;: &quot;Menyegel…&quot;,
+      &quot;flowStamped&quot;: &quot;Tersegel&quot;,
+      &quot;flowCrystallize&quot;: &quot;Salin prompt /crystallize&quot;,
+      &quot;flowCrystallizeCopied&quot;: &quot;Tersalin&quot;,
+      &quot;flowResetLayout&quot;: &quot;Reset tata letak&quot;,
       &quot;templates&quot;: &quot;Template&quot;,
       &quot;templatesHint&quot;: &quot;Jelajahi template starter dan lanjutan living doc&quot;,
       &quot;templatesIntro&quot;: &quot;Mulai dengan template starter yang sederhana atau langsung pakai bentuk lanjutan yang lebih lengkap.&quot;,
@@ -3442,7 +3760,37 @@
       &quot;guideLayer4FingerprintTitle&quot;: &quot;Sidik jari dan kesegaran&quot;,
       &quot;guideLayer4FingerprintBody&quot;: &quot;Sebuah sha256 dari struktur seksi pada saat kristalisasi. Merender banner ketika seksi bergeser tetapi meta tidak — coverage basi lebih buruk daripada tanpa coverage, sehingga drift menjadi nyaring.&quot;,
       &quot;guideLayer4CrystallizeTitle&quot;: &quot;Penyempurnaan pass-kedua, bukan gerbang authoring&quot;,
-      &quot;guideLayer4CrystallizeBody&quot;: &quot;Jangan mengkristalkan iterasi awal — faset belum mengendap. Jalankan `/crystallize &lt;doc&gt;` saat bentuk sudah stabil; skill mengusulkan faset, coverage, invarian, dan rationale dari apa yang sudah ada di dokumen. Jalankan ulang dengan `--refresh` saat struktur berubah.&quot;,
+      &quot;guideLayer4CrystallizeBody&quot;: &quot;Jangan mengkristalkan iterasi awal — faset belum mengendap. Jalankan `/crystallize &lt;doc&gt;` saat bentuk sudah stabil; skill mengusulkan faset, coverage, invarian, dan rationale dari apa yang sudah ada di dokumen. Jalankan ulang dengan `--refresh` saat struktur berubah. Buka tab Flow untuk melihat faset dan coverage muncul saat skill menuliskannya.&quot;,
+      &quot;guideLayer4FlowIntro&quot;: &quot;Tab Flow di compositor adalah permukaan utama untuk governance. Buka dokumen yang sudah dikristalkan, beralih ke Flow, dan lapisan tersebut menjadi kanvas: faset di kiri, seksi di tengah, invarian di kanan, dengan kabel bertipe di antara mereka.&quot;,
+      &quot;guideLayer4FlowFacets&quot;: &quot;Di kanvas Flow: kolom kiri. Faset orphan dirender sebagai kartu merah muda dengan badge Orphan, sehingga celah dalam coverage terlihat sekilas. Seret port kanan faset ke port kiri seksi untuk menambahkan edge coverage.&quot;,
+      &quot;guideLayer4FlowCoverage&quot;: &quot;Di kanvas Flow: kabel bezier abu-abu dari port kanan setiap faset ke port kiri seksi. Drift (seksi target telah dihapus) muncul sebagai kabel putus-putus merah yang mengarah ke kolom seksi. Klik kabel untuk menghapusnya.&quot;,
+      &quot;guideLayer4FlowInvariants&quot;: &quot;Di kanvas Flow: kolom kanan, panah berwarna kuning kecoklatan dengan kepala panah menunjuk ke seksi yang mereka atur. Klik chip Doc-wide pada invarian untuk beralih `appliesTo: [\&quot;*\&quot;]`; panah-panah itu berkumpul menjadi satu panah yang menunjuk ke jangkar virtual di atas kolom seksi. Seret ke seksi tertentu untuk mengubah cakupan.&quot;,
+      &quot;guideLayer4FlowFingerprint&quot;: &quot;Di kanvas Flow: banner berwarna kuning kecoklatan menempel di atas saat sidik jari basi. Kabel coverage dan invarian meredup dan desaturasi sehingga kondisi basi tak terbantahkan. Tombol Segel di banner menghitung ulang dan menyimpan sidik jari baru; tombol Crystallize menyalin `/crystallize &lt;doc&gt; --refresh` ke clipboard.&quot;,
+      &quot;guideLayer4ReadingTitle&quot;: &quot;Membaca kanvas Flow&quot;,
+      &quot;guideLayer4ReadingBody&quot;: &quot;Tiga kolom, tiga peran. Dua warna kabel, dua kondisi node. Satu footer miring per seksi.&quot;,
+      &quot;guideLayer4ReadingColumns&quot;: &quot;Kolom · Faset tujuan (kiri) → seksi (tengah) → invarian (kanan). Setiap kolom adalah peran governance yang diungkapkan sebagai kolom.&quot;,
+      &quot;guideLayer4ReadingWires&quot;: &quot;Kabel · Bezier abu-abu = coverage (faset dibawa oleh seksi). Bezier kuning kecoklatan dengan kepala panah = invarian (aturan mengatur seksi). Varian putus-putus menandakan drift atau pratinjau dalam progres.&quot;,
+      &quot;guideLayer4ReadingStates&quot;: &quot;Kondisi · Kartu faset merah muda + badge Orphan = tidak ada edge coverage. Kabel putus-putus merah = drift (menunjuk ke seksi yang hilang). Kabel yang meredup + desaturasi = metaFingerprint basi.&quot;,
+      &quot;guideLayer4ReadingStats&quot;: &quot;Bilah stats · Dipatri di atas: jumlah faset / seksi / coverage / invarian, rationale yang dinyatakan vs total, dan pil mencolok untuk jumlah orphan atau drift bila tidak nol.&quot;,
+      &quot;guideLayer4ReadingRationale&quot;: &quot;Rationale · Kartu miring bergaris di bagian bawah setiap node seksi. Stub putus-putus \&quot;belum ada rationale yang dinyatakan\&quot; muncul saat field kosong sehingga celah authoring tetap terlihat.&quot;,
+      &quot;guideLayer4EditingTitle&quot;: &quot;Menyunting lewat kanvas Flow&quot;,
+      &quot;guideLayer4EditingBody&quot;: &quot;Setiap interaksi menulis ke `docExtras` yang sama yang digunakan oleh `/crystallize` dan editor tabulasi, sehingga kanvas tetap sinkron dengan tampilan lain.&quot;,
+      &quot;guideLayer4EditingDrag&quot;: &quot;Seret port → buat kabel. Port-keluar faset ke port-masuk seksi menambahkan coverage (memilih cardId yang belum terpakai dari seksi). Port-keluar invarian ke port-kanan seksi menambahkan seksi itu ke `appliesTo`, menghapus `\&quot;*\&quot;` yang ada.&quot;,
+      &quot;guideLayer4EditingClick&quot;: &quot;Klik kabel → hapus. Klik chip Doc-wide pada invarian → alihkan cakupan doc-wide. Klik kartu rationale seksi → sunting kalimat inline via prompt.&quot;,
+      &quot;guideLayer4EditingRemove&quot;: &quot;× pada hover → hapus node. Faset mencascade coverage-nya; seksi sengaja meninggalkan edge coverage sebagai drift (sinyal visualnya tetap terlihat); invarian adalah penghapusan bersih.&quot;,
+      &quot;guideLayer4EditingPosition&quot;: &quot;Seret body node → reposisi di kanvas (`flowPosition` tersimpan di node). Klik ganda → kembali ke kolom. Tombol reset tata letak di bilah stats → hapus semua posisi khusus.&quot;,
+      &quot;guideLayer4DeepTitle&quot;: &quot;Sidik jari, kesegaran, dan momen kristalisasi&quot;,
+      &quot;guideLayer4DeepIntro&quot;: &quot;Sidik jari murah untuk dihitung dan memikul banyak beban. Memahami apa yang di-hash, kapan menyegelnya, dan apa arti kesegaran mengubah governance dari label statis menjadi kontrak hidup.&quot;,
+      &quot;guideLayer4DeepHashTitle&quot;: &quot;Apa yang di-hash oleh sidik jari&quot;,
+      &quot;guideLayer4DeepHashBody&quot;: &quot;Sebuah sha256 dari setiap id seksi, convergenceType, dan id kartu yang berurutan. Stabil terhadap suntingan prosa di dalam kartu; tidak stabil ketika seksi ditambahkan atau dihapus, diganti nama, atau direstrukturisasi. Pilihannya disengaja — governance mengikuti struktur, bukan konten.&quot;,
+      &quot;guideLayer4DeepMomentTitle&quot;: &quot;Momen kristalisasi&quot;,
+      &quot;guideLayer4DeepMomentBody&quot;: &quot;Anggap ini seperti git commit pada makna dokumen. Sebelum penyegelan, dokumen dalam mode penemuan bentuk dan governance akan mengkristalkan dekomposisi yang buruk. Setelah penyegelan, governance terpaku pada kondisi struktural yang tepat. Kristalkan saat bentuk sudah cukup stabil sehingga seminggu suntingan kecil tidak akan mengubah bentuknya.&quot;,
+      &quot;guideLayer4DeepStatesTitle&quot;: &quot;Tiga kondisi, tiga sikap&quot;,
+      &quot;guideLayer4DeepStatesBody&quot;: &quot;Hilang — tidak ada sidik jari, tidak ada yang diperiksa; agen kembali ke penurunan prosa. Segar — tersimpan cocok dengan saat ini; agen secara deterministik menargetkan kartu yang tepat via edge coverage. Basi — tersimpan berbeda dari saat ini; kabel meredup dan agen harus kembali ke prosa karena coverage mungkin menunjuk ke kartu yang maknanya telah bergeser.&quot;,
+      &quot;guideLayer4DeepRitualsTitle&quot;: &quot;Segel vs segarkan&quot;,
+      &quot;guideLayer4DeepRitualsBody&quot;: &quot;Segel (dari banner Flow) — hitung ulang sha256 dan simpan. Mempertahankan faset, coverage, invarian, dan rationale yang ada. Gunakan ketika suntingan struktural netral-semantik (nama seksi yang baru saja ditambahkan, id kartu yang diatur ulang). Segarkan via `/crystallize &lt;doc&gt; --refresh` — jalankan ulang skill. Mengusulkan faset dan coverage yang diperbarui untuk struktur baru; mempertahankan field yang disunting penulis. Gunakan ketika perubahan benar-benar bentuk baru.&quot;,
+      &quot;guideLayer4DeepBridgeTitle&quot;: &quot;Mengapa ini menjembatani authoring dan koherensi jangka panjang&quot;,
+      &quot;guideLayer4DeepBridgeBody&quot;: &quot;Tanpa sidik jari, pertanyaan \&quot;apakah dokumen ini masih koheren?\&quot; membutuhkan pembacaan ulang LLM dan penilaian manusia pada setiap iterasi. Dengan sidik jari, ini adalah perbandingan hash. Pelipatan itu — dari penilaian ke verifikasi — yang mengubah living doc dari struktur beropini menjadi substrat yang dapat diuji. Seiring waktu memungkinkan evaluasi empiris terhadap bentuk dokumen mana yang benar-benar bekerja baik untuk pembaca manusia maupun agen.&quot;,
       &quot;guideLayer5Title&quot;: &quot;Memperluas Kosakata&quot;,
       &quot;guideLayer5Tagline&quot;: &quot;Membuat tipe konvergensi baru ketika yang ada tidak cocok.&quot;,
       &quot;guideLayer6Title&quot;: &quot;Bekerja dengan Living Docs&quot;,
@@ -3647,10 +3995,13 @@
     return String(value || &#39;&#39;).toLowerCase().replace(/[^a-z0-9]+/g, &#39;-&#39;).replace(/^-|-$/g, &#39;&#39;).slice(0, 64);
   }
   function govSectionSignature() {
+    // Key names must match scripts/meta-fingerprint.mjs exactly — the Node
+    // stamper and this browser check produce different sha256 hashes otherwise,
+    // and every crystallized doc reads as stale in the Flow view. See #58.
     return JSON.stringify((state.sections || []).map((s) =&gt; ({
       id: String(s?.id || &#39;&#39;),
-      t: String(s?.convergenceType || &#39;&#39;),
-      c: (Array.isArray(s?.data) ? s.data : []).map((item) =&gt; String(item?.id || &#39;&#39;)).filter(Boolean),
+      type: String(s?.convergenceType || &#39;&#39;),
+      cards: (Array.isArray(s?.data) ? s.data : []).map((item) =&gt; String(item?.id || &#39;&#39;)).filter(Boolean),
     })));
   }
   async function govComputeFingerprint() {
@@ -10022,7 +10373,7 @@
     autoSave();
     const panel = document.getElementById(&#39;right-panel&#39;);
 
-    if (![&#39;visual&#39;, &#39;board&#39;, &#39;json&#39;].includes(state.previewTab)) state.previewTab = &#39;visual&#39;;
+    if (![&#39;visual&#39;, &#39;board&#39;, &#39;flow&#39;, &#39;json&#39;].includes(state.previewTab)) state.previewTab = &#39;visual&#39;;
     const json = buildJson();
     const title = t(&#39;preview&#39;);
 
@@ -10032,15 +10383,18 @@
         &lt;div class=&quot;preview-tabs&quot;&gt;
           &lt;button class=&quot;preview-tab${state.previewTab === &#39;visual&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;visual&quot;&gt;${esc(t(&#39;visual&#39;))}&lt;/button&gt;
           &lt;button class=&quot;preview-tab${state.previewTab === &#39;board&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;board&quot;&gt;${esc(t(&#39;board&#39;))}&lt;/button&gt;
+          &lt;button class=&quot;preview-tab${state.previewTab === &#39;flow&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;flow&quot;&gt;${esc(t(&#39;flow&#39;))}&lt;/button&gt;
           &lt;button class=&quot;preview-tab${state.previewTab === &#39;json&#39; ? &#39; active&#39; : &#39;&#39;}&quot; data-tab=&quot;json&quot;&gt;${esc(t(&#39;json&#39;))}&lt;/button&gt;
         &lt;/div&gt;
       &lt;/div&gt;
-      &lt;div class=&quot;preview-content&quot;&gt;
+      &lt;div class=&quot;preview-content${state.previewTab === &#39;flow&#39; ? &#39; preview-content-flow&#39; : &#39;&#39;}&quot;&gt;
         ${state.previewTab === &#39;json&#39;
           ? renderJsonPreview(json)
           : state.previewTab === &#39;board&#39;
             ? renderBoardPreview(json)
-            : renderVisualPreview(json)}
+            : state.previewTab === &#39;flow&#39;
+              ? renderFlowPreview(json)
+              : renderVisualPreview(json)}
       &lt;/div&gt;`;
 
     panel.querySelectorAll(&#39;.preview-tab&#39;).forEach(tab =&gt; {
@@ -10278,8 +10632,344 @@
       refreshFingerprintPill();
     }
 
+    if (state.previewTab === &#39;flow&#39;) {
+      requestAnimationFrame(() =&gt; drawFlowWires(json));
+      wireFlowInteractions(panel);
+    }
+
     syncFocusedSectionInPreview();
   }
+
+  let flowResizeHandler = null;
+  function ensureFlowResizeHook() {
+    if (flowResizeHandler) return;
+    flowResizeHandler = () =&gt; {
+      if (state.previewTab !== &#39;flow&#39;) return;
+      requestAnimationFrame(() =&gt; drawFlowWires(buildJson()));
+    };
+    window.addEventListener(&#39;resize&#39;, flowResizeHandler);
+  }
+  ensureFlowResizeHook();
+
+  function flowRerender() {
+    autoSave();
+    renderRight();
+  }
+
+  function wireFlowInteractions(panel) {
+    const canvas = panel.querySelector(&#39;#flow-canvas&#39;);
+    const wrap = panel.querySelector(&#39;#flow-canvas-wrap&#39;);
+    if (!canvas || !wrap) return;
+
+    // Remove a node (facet / section / invariant)
+    canvas.querySelectorAll(&#39;[data-flow-remove]&#39;).forEach((btn) =&gt; {
+      btn.addEventListener(&#39;click&#39;, (event) =&gt; {
+        event.stopPropagation();
+        const kind = btn.dataset.flowRemove;
+        const id = btn.dataset.flowId;
+        if (kind === &#39;facet&#39;) {
+          govSetFacets(govFacets().filter((f) =&gt; f.id !== id));
+          govSetCoverage(govCoverage().filter((c) =&gt; c.facetId !== id));
+        } else if (kind === &#39;invariant&#39;) {
+          govSetInvariants(govInvariants().filter((i) =&gt; i.id !== id));
+        } else if (kind === &#39;section&#39;) {
+          state.sections = state.sections.filter((s) =&gt; s.id !== id);
+          // coverage edges to the removed section become drift — keep them.
+        }
+        flowRerender();
+      });
+    });
+
+    // Remove a wire (coverage or invariant applies-to entry) via delegation,
+    // because wires are drawn async via requestAnimationFrame after this runs.
+    canvas.addEventListener(&#39;click&#39;, (event) =&gt; {
+      const hit = event.target.closest(&#39;[data-flow-edge]&#39;);
+      if (!hit) return;
+      const edgeKind = hit.dataset.flowEdge;
+      if (edgeKind === &#39;coverage&#39;) {
+        const idx = Number(hit.dataset.flowEdgeIndex);
+        const coverage = [...govCoverage()];
+        coverage.splice(idx, 1);
+        govSetCoverage(coverage);
+      } else if (edgeKind === &#39;invariant&#39;) {
+        const invIdx = Number(hit.dataset.flowInvIndex);
+        const tgtIdx = Number(hit.dataset.flowTargetIndex);
+        const invariants = [...govInvariants()];
+        if (invariants[invIdx] &amp;&amp; Array.isArray(invariants[invIdx].appliesTo)) {
+          invariants[invIdx] = {
+            ...invariants[invIdx],
+            appliesTo: invariants[invIdx].appliesTo.filter((_, i) =&gt; i !== tgtIdx),
+          };
+          govSetInvariants(invariants);
+        }
+      }
+      flowRerender();
+    });
+
+    // Toggle doc-wide invariant
+    canvas.querySelectorAll(&#39;[data-flow-docwide]&#39;).forEach((btn) =&gt; {
+      btn.addEventListener(&#39;click&#39;, (event) =&gt; {
+        event.stopPropagation();
+        const invId = btn.dataset.flowDocwide;
+        const invariants = [...govInvariants()];
+        const idx = invariants.findIndex((i) =&gt; i.id === invId);
+        if (idx &lt; 0) return;
+        const applies = Array.isArray(invariants[idx].appliesTo) ? [...invariants[idx].appliesTo] : [];
+        const hasStar = applies.includes(&#39;*&#39;);
+        invariants[idx] = {
+          ...invariants[idx],
+          appliesTo: hasStar ? applies.filter((a) =&gt; a !== &#39;*&#39;) : [&#39;*&#39;],
+        };
+        govSetInvariants(invariants);
+        flowRerender();
+      });
+    });
+
+    // Inline-edit rationale
+    canvas.querySelectorAll(&#39;.flow-rationale&#39;).forEach((el) =&gt; {
+      el.addEventListener(&#39;click&#39;, (event) =&gt; {
+        event.stopPropagation();
+        const sectionNode = el.closest(&#39;[data-flow-kind=&quot;section&quot;]&#39;);
+        if (!sectionNode) return;
+        const sid = sectionNode.dataset.flowId;
+        const section = state.sections.find((s) =&gt; s.id === sid);
+        if (!section) return;
+        const next = window.prompt(&#39;Rationale \u2014 why this convergence type, here:&#39;, section.rationale || &#39;&#39;);
+        if (next === null) return;
+        const trimmed = next.trim();
+        if (trimmed) section.rationale = trimmed; else delete section.rationale;
+        flowRerender();
+      });
+    });
+
+    // Freshness banner — async fingerprint check after render.
+    const banner = panel.querySelector(&#39;#flow-banner&#39;);
+    const stamp = panel.querySelector(&#39;[data-flow-stamp]&#39;);
+    const crystBtn = panel.querySelector(&#39;[data-flow-crystallize]&#39;);
+    const bannerTitle = panel.querySelector(&#39;#flow-banner-title&#39;);
+    const bannerMsg = panel.querySelector(&#39;#flow-banner-message&#39;);
+    const applyBannerState = async () =&gt; {
+      if (!banner || !wrap) return;
+      const stored = govFingerprint();
+      if (!stored) {
+        banner.dataset.state = &#39;missing&#39;;
+        wrap.classList.remove(&#39;flow-stale&#39;);
+        bannerTitle.textContent = t(&#39;flowMetaMissingTitle&#39;);
+        bannerMsg.textContent = t(&#39;flowMetaMissingBody&#39;);
+        return;
+      }
+      const current = await govComputeFingerprint();
+      if (!current || current === stored) {
+        banner.dataset.state = &#39;fresh&#39;;
+        banner.style.display = &#39;none&#39;;
+        wrap.classList.remove(&#39;flow-stale&#39;);
+        return;
+      }
+      banner.dataset.state = &#39;stale&#39;;
+      banner.style.display = &#39;&#39;;
+      wrap.classList.add(&#39;flow-stale&#39;);
+      bannerTitle.textContent = t(&#39;flowMetaStaleTitle&#39;);
+      bannerMsg.textContent = t(&#39;flowMetaStaleBody&#39;);
+    };
+    if (banner) {
+      banner.style.display = &#39;&#39;;
+      applyBannerState();
+    }
+
+    stamp?.addEventListener(&#39;click&#39;, async (event) =&gt; {
+      const btn = event.currentTarget;
+      const original = btn.textContent;
+      btn.disabled = true;
+      btn.textContent = t(&#39;flowStamping&#39;);
+      try {
+        const fp = await govComputeFingerprint();
+        if (fp) {
+          govSetFingerprint(fp);
+          btn.textContent = t(&#39;flowStamped&#39;);
+          setTimeout(() =&gt; { btn.disabled = false; btn.textContent = original; flowRerender(); }, 900);
+        } else {
+          btn.textContent = original;
+          btn.disabled = false;
+        }
+      } catch (err) {
+        btn.textContent = original;
+        btn.disabled = false;
+      }
+    });
+
+    crystBtn?.addEventListener(&#39;click&#39;, async (event) =&gt; {
+      const btn = event.currentTarget;
+      const label = currentOriginLabel() || &#39;&lt;path/to/doc.json&gt;&#39;;
+      const isStale = banner?.dataset.state === &#39;stale&#39;;
+      const prompt = `/crystallize ${label}${isStale ? &#39; --refresh&#39; : &#39;&#39;}`;
+      const original = btn.textContent;
+      try {
+        if (navigator.clipboard?.writeText) {
+          await navigator.clipboard.writeText(prompt);
+          btn.textContent = t(&#39;flowCrystallizeCopied&#39;);
+        } else {
+          window.prompt(&#39;Copy this prompt:&#39;, prompt);
+        }
+      } catch (err) {
+        window.prompt(&#39;Copy this prompt:&#39;, prompt);
+      }
+      setTimeout(() =&gt; { btn.textContent = original; }, 1600);
+    });
+
+    // Reset-layout button
+    panel.querySelector(&#39;[data-flow-reset-layout]&#39;)?.addEventListener(&#39;click&#39;, () =&gt; {
+      const facets = govFacets().map(({ flowPosition, ...rest }) =&gt; rest);
+      const invariants = govInvariants().map(({ flowPosition, ...rest }) =&gt; rest);
+      govSetFacets(facets);
+      govSetInvariants(invariants);
+      state.sections = state.sections.map(({ flowPosition, ...rest }) =&gt; rest);
+      flowRerender();
+    });
+
+    // Double-click a node to clear its flowPosition
+    canvas.querySelectorAll(&#39;.flow-node&#39;).forEach((node) =&gt; {
+      node.addEventListener(&#39;dblclick&#39;, (event) =&gt; {
+        if (event.target.closest(&#39;.flow-port, .flow-remove, [data-flow-docwide], .flow-rationale, [data-flow-reset-layout]&#39;)) return;
+        const kind = node.dataset.flowKind;
+        const id = node.dataset.flowId;
+        if (kind === &#39;facet&#39;) {
+          govSetFacets(govFacets().map((f) =&gt; f.id === id ? (({ flowPosition, ...r }) =&gt; r)(f) : f));
+        } else if (kind === &#39;invariant&#39;) {
+          govSetInvariants(govInvariants().map((i) =&gt; i.id === id ? (({ flowPosition, ...r }) =&gt; r)(i) : i));
+        } else if (kind === &#39;section&#39;) {
+          state.sections = state.sections.map((s) =&gt; s.id === id ? (({ flowPosition, ...r }) =&gt; r)(s) : s);
+        }
+        flowRerender();
+      });
+    });
+
+    // Drag a node body to reposition. Threshold distinguishes drag from click.
+    canvas.querySelectorAll(&#39;.flow-node&#39;).forEach((node) =&gt; {
+      node.addEventListener(&#39;pointerdown&#39;, (event) =&gt; {
+        if (event.target.closest(&#39;.flow-port, .flow-remove, [data-flow-docwide], .flow-rationale, [data-flow-reset-layout]&#39;)) return;
+        if (event.target.closest(&#39;[data-flow-edge]&#39;)) return;
+        event.preventDefault();
+        const canvasRect = canvas.getBoundingClientRect();
+        const nodeRect = node.getBoundingClientRect();
+        const offX = event.clientX - nodeRect.left;
+        const offY = event.clientY - nodeRect.top;
+        const startClientX = event.clientX;
+        const startClientY = event.clientY;
+        let dragging = false;
+        const onMove = (ev) =&gt; {
+          const dx = ev.clientX - startClientX;
+          const dy = ev.clientY - startClientY;
+          if (!dragging &amp;&amp; Math.hypot(dx, dy) &lt; 4) return;
+          dragging = true;
+          const currentCanvasRect = canvas.getBoundingClientRect();
+          const x = Math.max(0, ev.clientX - currentCanvasRect.left - offX);
+          const y = Math.max(0, ev.clientY - currentCanvasRect.top - offY);
+          node.classList.add(&#39;flow-node-dragging&#39;);
+          node.dataset.flowPositioned = &#39;true&#39;;
+          node.style.left = x + &#39;px&#39;;
+          node.style.top = y + &#39;px&#39;;
+          requestAnimationFrame(() =&gt; drawFlowWires(buildJson()));
+        };
+        const onUp = (ev) =&gt; {
+          document.removeEventListener(&#39;pointermove&#39;, onMove);
+          document.removeEventListener(&#39;pointerup&#39;, onUp);
+          node.classList.remove(&#39;flow-node-dragging&#39;);
+          if (!dragging) return;
+          const finalRect = node.getBoundingClientRect();
+          const finalCanvasRect = canvas.getBoundingClientRect();
+          const x = Math.round(finalRect.left - finalCanvasRect.left);
+          const y = Math.round(finalRect.top - finalCanvasRect.top);
+          const kind = node.dataset.flowKind;
+          const id = node.dataset.flowId;
+          if (kind === &#39;facet&#39;) {
+            govSetFacets(govFacets().map((f) =&gt; f.id === id ? { ...f, flowPosition: { x, y } } : f));
+          } else if (kind === &#39;invariant&#39;) {
+            govSetInvariants(govInvariants().map((i) =&gt; i.id === id ? { ...i, flowPosition: { x, y } } : i));
+          } else if (kind === &#39;section&#39;) {
+            state.sections = state.sections.map((s) =&gt; s.id === id ? { ...s, flowPosition: { x, y } } : s);
+          }
+          flowRerender();
+        };
+        document.addEventListener(&#39;pointermove&#39;, onMove);
+        document.addEventListener(&#39;pointerup&#39;, onUp);
+      });
+    });
+
+    // Drag to create a wire
+    canvas.querySelectorAll(&#39;[data-port=&quot;facet-out&quot;]&#39;).forEach((port) =&gt; {
+      port.addEventListener(&#39;pointerdown&#39;, (event) =&gt; {
+        event.preventDefault();
+        flowDragState = { kind: &#39;coverage&#39;, fromId: port.dataset.facetId, mouseX: event.clientX, mouseY: event.clientY };
+        port.classList.add(&#39;flow-port-dragging&#39;);
+        drawFlowWires(buildJson());
+      });
+    });
+    canvas.querySelectorAll(&#39;[data-port=&quot;inv-out&quot;]&#39;).forEach((port) =&gt; {
+      port.addEventListener(&#39;pointerdown&#39;, (event) =&gt; {
+        event.preventDefault();
+        flowDragState = { kind: &#39;invariant&#39;, fromId: port.dataset.invariantId, mouseX: event.clientX, mouseY: event.clientY };
+        port.classList.add(&#39;flow-port-dragging-inv&#39;);
+        drawFlowWires(buildJson());
+      });
+    });
+  }
+
+  // Global pointer handlers for the drag — simpler to keep on document.
+  let flowGlobalPointerHandlers = null;
+  function ensureFlowGlobalPointerHandlers() {
+    if (flowGlobalPointerHandlers) return;
+    flowGlobalPointerHandlers = {
+      move: (event) =&gt; {
+        if (!flowDragState) return;
+        flowDragState.mouseX = event.clientX;
+        flowDragState.mouseY = event.clientY;
+        drawFlowWires(buildJson());
+      },
+      up: (event) =&gt; {
+        if (!flowDragState) return;
+        document.querySelectorAll(&#39;.flow-port.flow-port-dragging, .flow-port.flow-port-dragging-inv&#39;)
+          .forEach((el) =&gt; el.classList.remove(&#39;flow-port-dragging&#39;, &#39;flow-port-dragging-inv&#39;));
+        const drag = flowDragState;
+        flowDragState = null;
+        const dropTarget = document.elementFromPoint(event.clientX, event.clientY);
+        if (drag.kind === &#39;coverage&#39;) {
+          const inPort = dropTarget?.closest(&#39;[data-port=&quot;section-in&quot;]&#39;);
+          if (inPort) {
+            const sectionId = inPort.dataset.sectionId;
+            const facetId = drag.fromId;
+            const section = state.sections.find((s) =&gt; s.id === sectionId);
+            const usedCards = new Set(govCoverage().filter((c) =&gt; c.sectionId === sectionId).map((c) =&gt; c.cardId));
+            const cardId = (section?.data || []).map((d) =&gt; d?.id).filter(Boolean).find((c) =&gt; !usedCards.has(c))
+              || (section?.data || []).map((d) =&gt; d?.id).filter(Boolean)[0]
+              || &#39;&#39;;
+            const exists = govCoverage().some((c) =&gt; c.facetId === facetId &amp;&amp; c.sectionId === sectionId &amp;&amp; (c.cardId || &#39;&#39;) === cardId);
+            if (!exists) {
+              govSetCoverage([...govCoverage(), cardId ? { facetId, sectionId, cardId } : { facetId, sectionId }]);
+            }
+          }
+        } else if (drag.kind === &#39;invariant&#39;) {
+          const invInPort = dropTarget?.closest(&#39;[data-port=&quot;section-inv-in&quot;]&#39;);
+          if (invInPort) {
+            const sectionId = invInPort.dataset.sectionId;
+            const invariants = [...govInvariants()];
+            const idx = invariants.findIndex((i) =&gt; i.id === drag.fromId);
+            if (idx &gt;= 0) {
+              const applies = Array.isArray(invariants[idx].appliesTo) ? [...invariants[idx].appliesTo] : [];
+              const starIdx = applies.indexOf(&#39;*&#39;);
+              if (starIdx &gt;= 0) applies.splice(starIdx, 1);
+              if (!applies.includes(sectionId)) applies.push(sectionId);
+              invariants[idx] = { ...invariants[idx], appliesTo: applies };
+              govSetInvariants(invariants);
+            }
+          }
+        }
+        flowRerender();
+      },
+    };
+    document.addEventListener(&#39;pointermove&#39;, flowGlobalPointerHandlers.move);
+    document.addEventListener(&#39;pointerup&#39;,   flowGlobalPointerHandlers.up);
+  }
+  ensureFlowGlobalPointerHandlers();
 
   function renderTemplatesView() {
     if (!TEMPLATES.length) {
@@ -10360,6 +11050,261 @@
         ${renderTemplateGroup(&#39;starterTemplates&#39;, &#39;starterTemplatesIntro&#39;, starterTemplates)}
         ${renderTemplateGroup(&#39;advancedTemplates&#39;, &#39;advancedTemplatesIntro&#39;, advancedTemplates)}
       &lt;/div&gt;`;
+  }
+
+  function deriveFlowCoherence(json) {
+    const facets = Array.isArray(json.objectiveFacets) ? json.objectiveFacets : [];
+    const coverage = Array.isArray(json.coverage) ? json.coverage : [];
+    const invariants = Array.isArray(json.invariants) ? json.invariants : [];
+    const sections = Array.isArray(json.sections) ? json.sections : [];
+    const knownSectionIds = new Set(sections.map((s) =&gt; s.id));
+    const facetStatus = new Map();
+    for (const facet of facets) {
+      const edges = coverage.filter((c) =&gt; c.facetId === facet.id);
+      const carryingSectionIds = [...new Set(edges.map((e) =&gt; e.sectionId))];
+      const anyDrift = edges.some((e) =&gt; !knownSectionIds.has(e.sectionId));
+      let status;
+      if (anyDrift) status = &#39;drift&#39;;
+      else if (edges.length === 0) status = &#39;orphaned&#39;;
+      else status = &#39;covered&#39;;
+      facetStatus.set(facet.id, { status, carryingSectionIds });
+    }
+    return { facets, coverage, invariants, sections, knownSectionIds, facetStatus };
+  }
+
+  function renderFlowPreview(json) {
+    const state = deriveFlowCoherence(json);
+    const { facets, coverage, invariants, sections } = state;
+    const hasGovernance = facets.length &gt; 0 || coverage.length &gt; 0 || invariants.length &gt; 0;
+
+    if (!hasGovernance) {
+      return `
+        &lt;div class=&quot;flow-empty&quot;&gt;
+          &lt;strong&gt;${esc(t(&#39;flowEmptyTitle&#39;))}&lt;/strong&gt;
+          ${esc(t(&#39;flowMissingGovernance&#39;))}
+        &lt;/div&gt;`;
+    }
+
+    const orphanCount = [...state.facetStatus.values()].filter((v) =&gt; v.status === &#39;orphaned&#39;).length;
+    const driftCount = [...state.facetStatus.values()].filter((v) =&gt; v.status === &#39;drift&#39;).length;
+    const rationalesDeclared = sections.filter((s) =&gt; (s.rationale || &#39;&#39;).trim().length &gt; 0).length;
+    const invArrows = invariants.reduce((n, inv) =&gt; n + (Array.isArray(inv.appliesTo) ? inv.appliesTo.length : 0), 0);
+
+    const anyPositioned =
+      facets.some((f) =&gt; f.flowPosition) ||
+      sections.some((s) =&gt; s.flowPosition) ||
+      invariants.some((i) =&gt; i.flowPosition);
+
+    const statsHtml = `
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${facets.length}&lt;/strong&gt; facets&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${sections.length}&lt;/strong&gt; sections&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${coverage.length}&lt;/strong&gt; coverage edges&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${invariants.length}&lt;/strong&gt; invariants \u00b7 ${invArrows} arrows&lt;/span&gt;
+      &lt;span class=&quot;flow-stat&quot;&gt;&lt;strong&gt;${rationalesDeclared}/${sections.length}&lt;/strong&gt; rationales&lt;/span&gt;
+      ${orphanCount &gt; 0 ? `&lt;span class=&quot;flow-stat flow-stat-bad&quot;&gt;&lt;strong&gt;${orphanCount}&lt;/strong&gt; orphaned&lt;/span&gt;` : &#39;&#39;}
+      ${driftCount &gt; 0 ? `&lt;span class=&quot;flow-stat flow-stat-warn&quot;&gt;&lt;strong&gt;${driftCount}&lt;/strong&gt; drifted&lt;/span&gt;` : &#39;&#39;}
+      ${anyPositioned ? `&lt;button type=&quot;button&quot; class=&quot;flow-reset-layout-btn&quot; data-flow-reset-layout title=&quot;Clear all flowPosition values&quot;&gt;${esc(t(&#39;flowResetLayout&#39;))}&lt;/button&gt;` : &#39;&#39;}`;
+
+    const positionStyle = (node) =&gt; {
+      const p = node?.flowPosition;
+      if (!p || typeof p !== &#39;object&#39;) return &#39;&#39;;
+      const x = Number.isFinite(p.x) ? p.x : 0;
+      const y = Number.isFinite(p.y) ? p.y : 0;
+      return ` data-flow-positioned=&quot;true&quot; style=&quot;left:${x}px;top:${y}px&quot;`;
+    };
+
+    const facetsHtml = facets.map((facet) =&gt; {
+      const { status } = state.facetStatus.get(facet.id) || { status: &#39;orphaned&#39; };
+      const orphan = status === &#39;orphaned&#39;;
+      return `
+        &lt;article class=&quot;flow-node ${orphan ? &#39;flow-node-orphan&#39; : &#39;&#39;}&quot; data-flow-kind=&quot;facet&quot; data-flow-id=&quot;${esc(facet.id)}&quot;${positionStyle(facet)}&gt;
+          &lt;button type=&quot;button&quot; class=&quot;flow-remove&quot; data-flow-remove=&quot;facet&quot; data-flow-id=&quot;${esc(facet.id)}&quot; title=&quot;Remove facet&quot;&gt;\u00d7&lt;/button&gt;
+          &lt;div class=&quot;flow-node-header&quot;&gt;
+            &lt;h5&gt;${esc(facet.name || facet.id)}&lt;/h5&gt;
+            ${orphan ? `&lt;span class=&quot;flow-badge flow-badge-orphan&quot;&gt;Orphan&lt;/span&gt;` : &#39;&#39;}
+          &lt;/div&gt;
+          &lt;div class=&quot;flow-node-id&quot;&gt;${esc(facet.id)}&lt;/div&gt;
+          ${facet.description ? `&lt;div class=&quot;flow-node-body&quot;&gt;${esc(facet.description)}&lt;/div&gt;` : &#39;&#39;}
+          &lt;span class=&quot;flow-port flow-port-out&quot; data-port=&quot;facet-out&quot; data-facet-id=&quot;${esc(facet.id)}&quot; title=&quot;Drag to a section&#39;s left port to add coverage&quot;&gt;&lt;/span&gt;
+        &lt;/article&gt;`;
+    }).join(&#39;&#39;);
+
+    const sectionsHtml = sections.map((section) =&gt; {
+      const rationale = (section.rationale || &#39;&#39;).trim();
+      const rationaleHtml = rationale
+        ? `&lt;div class=&quot;flow-rationale&quot;&gt;${esc(rationale)}&lt;/div&gt;`
+        : `&lt;div class=&quot;flow-rationale flow-rationale-empty&quot;&gt;\u2014 no rationale declared yet \u2014&lt;/div&gt;`;
+      const cards = Array.isArray(section.data) ? section.data : [];
+      const chips = cards.filter((c) =&gt; c &amp;&amp; c.id).slice(0, 8).map((c) =&gt; `&lt;span class=&quot;flow-card-chip&quot;&gt;${esc(c.id)}&lt;/span&gt;`).join(&#39;&#39;);
+      const overflow = cards.filter((c) =&gt; c &amp;&amp; c.id).length - 8;
+      return `
+        &lt;article class=&quot;flow-node&quot; data-flow-kind=&quot;section&quot; data-flow-id=&quot;${esc(section.id)}&quot;${positionStyle(section)}&gt;
+          &lt;button type=&quot;button&quot; class=&quot;flow-remove&quot; data-flow-remove=&quot;section&quot; data-flow-id=&quot;${esc(section.id)}&quot; title=&quot;Remove section&quot;&gt;\u00d7&lt;/button&gt;
+          &lt;div class=&quot;flow-node-header&quot;&gt;
+            &lt;h5&gt;${esc(section.title || section.id)}&lt;/h5&gt;
+            &lt;span class=&quot;flow-badge flow-badge-ct&quot;&gt;${esc(section.convergenceType || &#39;&#39;)}&lt;/span&gt;
+          &lt;/div&gt;
+          &lt;div class=&quot;flow-node-id&quot;&gt;${esc(section.id)}&lt;/div&gt;
+          ${chips ? `&lt;div class=&quot;flow-card-chips&quot;&gt;${chips}${overflow &gt; 0 ? `&lt;span class=&quot;flow-card-chip&quot;&gt;+${overflow}&lt;/span&gt;` : &#39;&#39;}&lt;/div&gt;` : &#39;&#39;}
+          ${rationaleHtml}
+          &lt;span class=&quot;flow-port flow-port-in-left&quot; data-port=&quot;section-in&quot; data-section-id=&quot;${esc(section.id)}&quot; title=&quot;Coverage in-port&quot;&gt;&lt;/span&gt;
+          &lt;span class=&quot;flow-port flow-port-in-right&quot; data-port=&quot;section-inv-in&quot; data-section-id=&quot;${esc(section.id)}&quot; title=&quot;Invariant applies-to in-port&quot;&gt;&lt;/span&gt;
+        &lt;/article&gt;`;
+    }).join(&#39;&#39;);
+
+    const invariantsHtml = invariants.map((inv) =&gt; {
+      const applies = Array.isArray(inv.appliesTo) ? inv.appliesTo : [];
+      const docWide = applies.includes(&#39;*&#39;);
+      const docWideTitle = docWide
+        ? &#39;Doc-wide — click to scope to individual sections&#39;
+        : &#39;Click to make doc-wide (appliesTo: [&quot;*&quot;]); removes any section-specific entries&#39;;
+      return `
+        &lt;article class=&quot;flow-node flow-invariant&quot; data-flow-kind=&quot;invariant&quot; data-flow-id=&quot;${esc(inv.id)}&quot;${positionStyle(inv)}&gt;
+          &lt;button type=&quot;button&quot; class=&quot;flow-remove&quot; data-flow-remove=&quot;invariant&quot; data-flow-id=&quot;${esc(inv.id)}&quot; title=&quot;Remove invariant&quot;&gt;\u00d7&lt;/button&gt;
+          &lt;div class=&quot;flow-node-header&quot;&gt;
+            &lt;h5&gt;${esc(inv.name || inv.id)}&lt;/h5&gt;
+            &lt;button type=&quot;button&quot; class=&quot;flow-badge flow-badge-docwide${docWide ? &#39; flow-badge-docwide-active&#39; : &#39;&#39;}&quot; data-flow-docwide=&quot;${esc(inv.id)}&quot; title=&quot;${esc(docWideTitle)}&quot;&gt;Doc-wide&lt;/button&gt;
+          &lt;/div&gt;
+          &lt;div class=&quot;flow-node-id&quot;&gt;${esc(inv.id)}&lt;/div&gt;
+          ${inv.statement ? `&lt;div class=&quot;flow-invariant-statement&quot;&gt;${esc(inv.statement)}&lt;/div&gt;` : &#39;&#39;}
+          &lt;span class=&quot;flow-port flow-port-inv-out&quot; data-port=&quot;inv-out&quot; data-invariant-id=&quot;${esc(inv.id)}&quot; title=&quot;Drag to a section&#39;s right port to govern it&quot;&gt;&lt;/span&gt;
+        &lt;/article&gt;`;
+    }).join(&#39;&#39;);
+
+    return `
+      &lt;div class=&quot;flow-view&quot; id=&quot;flow-view&quot;&gt;
+        &lt;div class=&quot;flow-banner&quot; id=&quot;flow-banner&quot; data-state=&quot;checking&quot;&gt;
+          &lt;div class=&quot;flow-banner-body&quot;&gt;&lt;strong id=&quot;flow-banner-title&quot;&gt;${esc(t(&#39;flowMetaChecking&#39;))}&lt;/strong&gt; &lt;span id=&quot;flow-banner-message&quot;&gt;${esc(t(&#39;flowMetaCheckingBody&#39;))}&lt;/span&gt;&lt;/div&gt;
+          &lt;div class=&quot;flow-banner-actions&quot;&gt;
+            &lt;button type=&quot;button&quot; class=&quot;flow-banner-btn&quot; data-flow-stamp&gt;${esc(t(&#39;flowStampNow&#39;))}&lt;/button&gt;
+            &lt;button type=&quot;button&quot; class=&quot;flow-banner-btn flow-banner-btn-primary&quot; data-flow-crystallize&gt;${esc(t(&#39;flowCrystallize&#39;))}&lt;/button&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+        &lt;div class=&quot;flow-stats&quot;&gt;${statsHtml}&lt;/div&gt;
+        &lt;div class=&quot;flow-canvas-wrap&quot; id=&quot;flow-canvas-wrap&quot;&gt;
+          &lt;div class=&quot;flow-canvas&quot; id=&quot;flow-canvas&quot;&gt;
+            &lt;svg class=&quot;flow-wires&quot; id=&quot;flow-wires&quot; aria-hidden=&quot;true&quot;&gt;
+              &lt;defs&gt;
+                &lt;marker id=&quot;flow-arrow-inv&quot; viewBox=&quot;0 0 10 10&quot; refX=&quot;9&quot; refY=&quot;5&quot; markerWidth=&quot;6&quot; markerHeight=&quot;6&quot; orient=&quot;auto-start-reverse&quot;&gt;
+                  &lt;path d=&quot;M 0 0 L 10 5 L 0 10 z&quot; fill=&quot;#d97706&quot;/&gt;
+                &lt;/marker&gt;
+              &lt;/defs&gt;
+            &lt;/svg&gt;
+            &lt;div class=&quot;flow-col flow-col-facets&quot;&gt;
+              &lt;h4&gt;${esc(t(&#39;flowColFacets&#39;))}&lt;span class=&quot;flow-col-count&quot;&gt;${facets.length}&lt;/span&gt;&lt;/h4&gt;
+              &lt;div class=&quot;flow-nodes&quot;&gt;${facetsHtml}&lt;/div&gt;
+            &lt;/div&gt;
+            &lt;div class=&quot;flow-col flow-col-sections&quot;&gt;
+              &lt;h4&gt;${esc(t(&#39;flowColSections&#39;))}&lt;span class=&quot;flow-col-count&quot;&gt;${sections.length}&lt;/span&gt;&lt;/h4&gt;
+              &lt;div class=&quot;flow-nodes&quot;&gt;${sectionsHtml}&lt;/div&gt;
+            &lt;/div&gt;
+            &lt;div class=&quot;flow-col flow-col-invariants&quot;&gt;
+              &lt;h4&gt;${esc(t(&#39;flowColInvariants&#39;))}&lt;span class=&quot;flow-col-count&quot;&gt;${invariants.length}&lt;/span&gt;&lt;/h4&gt;
+              &lt;div class=&quot;flow-nodes&quot;&gt;${invariantsHtml}&lt;/div&gt;
+            &lt;/div&gt;
+          &lt;/div&gt;
+        &lt;/div&gt;
+      &lt;/div&gt;`;
+  }
+
+  let flowDragState = null;
+
+  function drawFlowWires(doc) {
+    const wrap = document.getElementById(&#39;flow-canvas-wrap&#39;);
+    const wires = document.getElementById(&#39;flow-wires&#39;);
+    const canvas = document.getElementById(&#39;flow-canvas&#39;);
+    if (!wrap || !wires || !canvas) return;
+
+    const coverage = Array.isArray(doc.coverage) ? doc.coverage : [];
+    const invariants = Array.isArray(doc.invariants) ? doc.invariants : [];
+    const sections = Array.isArray(doc.sections) ? doc.sections : [];
+    const knownSectionIds = new Set(sections.map((s) =&gt; s.id));
+
+    const canvasRect = canvas.getBoundingClientRect();
+    wires.setAttribute(&#39;width&#39;,  String(canvasRect.width));
+    wires.setAttribute(&#39;height&#39;, String(canvasRect.height));
+
+    const svgX = (rect) =&gt; rect.left + rect.width / 2 - canvasRect.left;
+    const svgY = (rect) =&gt; rect.top + rect.height / 2 - canvasRect.top;
+    const cssEscape = (s) =&gt; String(s).replace(/[^a-zA-Z0-9_-]/g, (ch) =&gt; `\\${ch}`);
+    const bezier = (x1, y1, x2, y2) =&gt; {
+      const mid = (x1 + x2) / 2;
+      return `M ${x1} ${y1} C ${mid} ${y1}, ${mid} ${y2}, ${x2} ${y2}`;
+    };
+
+    const paths = [];
+
+    // Coverage wires
+    coverage.forEach((edge, idx) =&gt; {
+      const from = canvas.querySelector(`[data-port=&quot;facet-out&quot;][data-facet-id=&quot;${cssEscape(edge.facetId)}&quot;]`);
+      if (!from) return;
+      const drift = !knownSectionIds.has(edge.sectionId);
+      let toX, toY;
+      if (!drift) {
+        const sectionEl = canvas.querySelector(`[data-flow-kind=&quot;section&quot;][data-flow-id=&quot;${cssEscape(edge.sectionId)}&quot;]`);
+        const toPort = sectionEl?.querySelector(&#39;[data-port=&quot;section-in&quot;]&#39;);
+        if (!toPort) return;
+        const r = toPort.getBoundingClientRect();
+        toX = svgX(r); toY = svgY(r);
+      } else {
+        const fr = from.getBoundingClientRect();
+        toX = canvasRect.width * 0.62;
+        toY = svgY(fr);
+      }
+      const fr = from.getBoundingClientRect();
+      const d = bezier(svgX(fr), svgY(fr), toX, toY);
+      paths.push(`&lt;path class=&quot;flow-wire-hit&quot; d=&quot;${d}&quot; data-flow-edge=&quot;coverage&quot; data-flow-edge-index=&quot;${idx}&quot;&gt;&lt;/path&gt;`);
+      paths.push(`&lt;path class=&quot;flow-wire-coverage ${drift ? &#39;flow-wire-drift&#39; : &#39;&#39;}&quot; d=&quot;${d}&quot;/&gt;`);
+    });
+
+    // Invariant arrows — one path per (invariantIdx, appliesToIdx) pair
+    invariants.forEach((inv, invIdx) =&gt; {
+      const from = canvas.querySelector(`[data-port=&quot;inv-out&quot;][data-invariant-id=&quot;${cssEscape(inv.id)}&quot;]`);
+      if (!from) return;
+      const applies = Array.isArray(inv.appliesTo) ? inv.appliesTo : [];
+      const fr = from.getBoundingClientRect();
+      const fromX = svgX(fr), fromY = svgY(fr);
+      applies.forEach((target, targetIdx) =&gt; {
+        let toX, toY;
+        if (target === &#39;*&#39;) {
+          const sectionsCol = canvas.querySelector(&#39;.flow-col-sections&#39;)?.getBoundingClientRect();
+          toX = sectionsCol ? sectionsCol.right - canvasRect.left + 6 : canvasRect.width * 0.62;
+          toY = sectionsCol ? sectionsCol.top - canvasRect.top - 10 : fromY;
+        } else {
+          const sectionEl = canvas.querySelector(`[data-flow-kind=&quot;section&quot;][data-flow-id=&quot;${cssEscape(target)}&quot;]`);
+          const toPort = sectionEl?.querySelector(&#39;[data-port=&quot;section-inv-in&quot;]&#39;);
+          if (!toPort) return;
+          const r = toPort.getBoundingClientRect();
+          toX = svgX(r); toY = svgY(r);
+        }
+        const d = bezier(fromX, fromY, toX, toY);
+        paths.push(`&lt;path class=&quot;flow-wire-hit&quot; d=&quot;${d}&quot; data-flow-edge=&quot;invariant&quot; data-flow-inv-index=&quot;${invIdx}&quot; data-flow-target-index=&quot;${targetIdx}&quot;&gt;&lt;/path&gt;`);
+        paths.push(`&lt;path class=&quot;flow-wire-invariant&quot; d=&quot;${d}&quot; marker-end=&quot;url(#flow-arrow-inv)&quot;/&gt;`);
+      });
+    });
+
+    // Drag preview
+    if (flowDragState) {
+      const portSel = flowDragState.kind === &#39;invariant&#39;
+        ? `[data-port=&quot;inv-out&quot;][data-invariant-id=&quot;${cssEscape(flowDragState.fromId)}&quot;]`
+        : `[data-port=&quot;facet-out&quot;][data-facet-id=&quot;${cssEscape(flowDragState.fromId)}&quot;]`;
+      const from = canvas.querySelector(portSel);
+      if (from) {
+        const fr = from.getBoundingClientRect();
+        const fromX = svgX(fr), fromY = svgY(fr);
+        const toX = flowDragState.mouseX - canvasRect.left;
+        const toY = flowDragState.mouseY - canvasRect.top;
+        const d = bezier(fromX, fromY, toX, toY);
+        const cls = flowDragState.kind === &#39;invariant&#39;
+          ? &#39;flow-wire-invariant flow-wire-preview&#39;
+          : &#39;flow-wire-coverage flow-wire-preview&#39;;
+        const marker = flowDragState.kind === &#39;invariant&#39; ? &#39; marker-end=&quot;url(#flow-arrow-inv)&quot;&#39; : &#39;&#39;;
+        paths.push(`&lt;path class=&quot;${cls}&quot; d=&quot;${d}&quot;${marker}/&gt;`);
+      }
+    }
+
+    const defs = wires.querySelector(&#39;defs&#39;);
+    wires.innerHTML = (defs ? defs.outerHTML : &#39;&#39;) + paths.join(&#39;&#39;);
   }
 
   function renderJsonPreview(json) {
@@ -11146,12 +12091,45 @@ open docs/living-doc-compositor.html&lt;/pre&gt;
           &lt;div class=&quot;guide-layer-body&quot;&gt;
             &lt;p&gt;${esc(t(&#39;guideLayer4Body1&#39;))}&lt;/p&gt;
             &lt;p&gt;${esc(t(&#39;guideLayer4Body2&#39;))}&lt;/p&gt;
+            &lt;p&gt;&lt;em&gt;${esc(t(&#39;guideLayer4FlowIntro&#39;))}&lt;/em&gt;&lt;/p&gt;
 
             &lt;div class=&quot;guide-card-stack&quot;&gt;
-              ${infoCard(t(&#39;guideLayer4FacetsTitle&#39;), t(&#39;guideLayer4FacetsBody&#39;))}
-              ${infoCard(t(&#39;guideLayer4CoverageTitle&#39;), t(&#39;guideLayer4CoverageBody&#39;))}
-              ${infoCard(t(&#39;guideLayer4InvariantsTitle&#39;), t(&#39;guideLayer4InvariantsBody&#39;))}
-              ${infoCard(t(&#39;guideLayer4FingerprintTitle&#39;), t(&#39;guideLayer4FingerprintBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4FacetsTitle&#39;), t(&#39;guideLayer4FacetsBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowFacets&#39;))}&lt;/p&gt;`)}
+              ${infoCard(t(&#39;guideLayer4CoverageTitle&#39;), t(&#39;guideLayer4CoverageBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowCoverage&#39;))}&lt;/p&gt;`)}
+              ${infoCard(t(&#39;guideLayer4InvariantsTitle&#39;), t(&#39;guideLayer4InvariantsBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowInvariants&#39;))}&lt;/p&gt;`)}
+              ${infoCard(t(&#39;guideLayer4FingerprintTitle&#39;), t(&#39;guideLayer4FingerprintBody&#39;), `&lt;p style=&quot;margin-top:8px;font-size:12.5px;color:var(--ink)&quot;&gt;&lt;strong&gt;Flow:&lt;/strong&gt; ${esc(t(&#39;guideLayer4FlowFingerprint&#39;))}&lt;/p&gt;`)}
+            &lt;/div&gt;
+
+            &lt;h3&gt;${esc(t(&#39;guideLayer4ReadingTitle&#39;))}&lt;/h3&gt;
+            &lt;p style=&quot;color:var(--muted)&quot;&gt;${esc(t(&#39;guideLayer4ReadingBody&#39;))}&lt;/p&gt;
+            &lt;div class=&quot;guide-card-stack&quot;&gt;
+              ${infoCard(&#39;Columns&#39;, t(&#39;guideLayer4ReadingColumns&#39;))}
+              ${infoCard(&#39;Wires&#39;, t(&#39;guideLayer4ReadingWires&#39;))}
+              ${infoCard(&#39;States&#39;, t(&#39;guideLayer4ReadingStates&#39;))}
+              ${infoCard(&#39;Stats bar&#39;, t(&#39;guideLayer4ReadingStats&#39;))}
+              ${infoCard(&#39;Rationale&#39;, t(&#39;guideLayer4ReadingRationale&#39;))}
+            &lt;/div&gt;
+
+            &lt;h3&gt;${esc(t(&#39;guideLayer4DeepTitle&#39;))}&lt;/h3&gt;
+            &lt;p style=&quot;color:var(--muted)&quot;&gt;${esc(t(&#39;guideLayer4DeepIntro&#39;))}&lt;/p&gt;
+            &lt;div class=&quot;guide-card-stack&quot;&gt;
+              ${infoCard(t(&#39;guideLayer4DeepHashTitle&#39;), t(&#39;guideLayer4DeepHashBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4DeepMomentTitle&#39;), t(&#39;guideLayer4DeepMomentBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4DeepStatesTitle&#39;), t(&#39;guideLayer4DeepStatesBody&#39;))}
+              ${infoCard(t(&#39;guideLayer4DeepRitualsTitle&#39;), t(&#39;guideLayer4DeepRitualsBody&#39;))}
+            &lt;/div&gt;
+            &lt;div class=&quot;guide-accent-callout&quot; style=&quot;margin-top:10px&quot;&gt;
+              &lt;strong&gt;${esc(t(&#39;guideLayer4DeepBridgeTitle&#39;))}&lt;/strong&gt;&lt;br /&gt;
+              &lt;span style=&quot;color:var(--muted);font-size:13.5px&quot;&gt;${esc(t(&#39;guideLayer4DeepBridgeBody&#39;))}&lt;/span&gt;
+            &lt;/div&gt;
+
+            &lt;h3&gt;${esc(t(&#39;guideLayer4EditingTitle&#39;))}&lt;/h3&gt;
+            &lt;p style=&quot;color:var(--muted)&quot;&gt;${esc(t(&#39;guideLayer4EditingBody&#39;))}&lt;/p&gt;
+            &lt;div class=&quot;guide-card-stack&quot;&gt;
+              ${stepCard(1, &#39;Drag a port&#39;, esc(t(&#39;guideLayer4EditingDrag&#39;)))}
+              ${stepCard(2, &#39;Click a wire or chip&#39;, esc(t(&#39;guideLayer4EditingClick&#39;)))}
+              ${stepCard(3, &#39;Delete a node&#39;, esc(t(&#39;guideLayer4EditingRemove&#39;)))}
+              ${stepCard(4, &#39;Reposition and reset&#39;, esc(t(&#39;guideLayer4EditingPosition&#39;)))}
             &lt;/div&gt;
 
             &lt;div class=&quot;guide-accent-callout&quot;&gt;
@@ -12868,7 +13846,7 @@ open docs/living-doc-compositor.html&lt;/pre&gt;
 
     <div class="snapshot-item">
       <span class="snapshot-label">Generated</span>
-      <span class="snapshot-value"><time datetime="2026-04-17T08:28:24.237Z" title="2026-04-17T08:28:24.237Z" data-snapshot-anchor="generated-at" id="snapshot-generated-at">2026-04-17T08:28:24.237Z</time></span>
+      <span class="snapshot-value"><time datetime="2026-04-17T13:00:54.328Z" title="2026-04-17T13:00:54.328Z" data-snapshot-anchor="generated-at" id="snapshot-generated-at">2026-04-17T13:00:54.328Z</time></span>
     </div>
 
     <div class="snapshot-item">
@@ -13458,7 +14436,7 @@ open docs/living-doc-compositor.html&lt;/pre&gt;
     </section>
 
 
-          <p class="footnote" style="margin-top:40px">Living Doc Compositor v0.1.0-c54a154 (2026-04-17)</p>
+          <p class="footnote" style="margin-top:40px">Living Doc Compositor v0.1.0-0103671 (2026-04-17)</p>
         </div>
 
     <section id="board-view" class="view-panel board-view" data-view-panel="board" hidden>


### PR DESCRIPTION
Follow-up to #59. Re-render the four governance-backed docs in this repo so their embedded compositor carries the fingerprint fix.

Source JSON unchanged — no governance data changed, no content changed, just the compositor asset that ships inside each HTML.

Refs #58, #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)