### PR TITLE
Fix stale fingerprint banner on fresh iframe load

### DIFF
--- a/docs/living-doc-compositor.html
+++ b/docs/living-doc-compositor.html
@@ -2537,7 +2537,12 @@
 
   /* ── Auto-save ── */
   const STORAGE_KEY = 'living-doc-compositor-state';
+  const STORAGE_ACTIVE_KEY = STORAGE_KEY + ':active';
   const SETTINGS_STORAGE_KEY = 'living-doc-compositor-settings';
+  function getDocStorageKey() {
+    const id = state.docExtras?.docId || state.docExtras?.canonicalOrigin || '_default';
+    return STORAGE_KEY + ':' + id;
+  }
   function isLocalLibraryDiscoveryContext() {
     try {
       const { protocol, hostname } = window.location;
@@ -2556,8 +2561,13 @@
   let appSettings = loadSettings();
 
   function autoSave() {
+    // Embedded mode: block writes until the first postMessage-driven
+    // applyDocumentData has landed. Otherwise a default-empty state can
+    // shadow the doc on disk and produce a stale fingerprint banner. See #58.
+    if (state.pendingDocLoad) return;
     try {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify({
+      const activeId = state.docExtras?.docId || state.docExtras?.canonicalOrigin || '_default';
+      localStorage.setItem(getDocStorageKey(), JSON.stringify({
         title: state.title,
         subtitle: state.subtitle,
         brand: state.brand,
@@ -2567,12 +2577,26 @@
         sections: state.sections,
         locale,
       }));
+      localStorage.setItem(STORAGE_ACTIVE_KEY, activeId);
     } catch {}
   }
 
   function autoLoad() {
     try {
-      const saved = localStorage.getItem(STORAGE_KEY);
+      // Legacy single-key state migrates into a per-doc slot on first boot.
+      const legacy = localStorage.getItem(STORAGE_KEY);
+      if (legacy && !localStorage.getItem(STORAGE_ACTIVE_KEY)) {
+        try {
+          const parsed = JSON.parse(legacy);
+          const id = parsed?.docExtras?.docId || parsed?.docExtras?.canonicalOrigin || '_default';
+          localStorage.setItem(STORAGE_KEY + ':' + id, legacy);
+          localStorage.setItem(STORAGE_ACTIVE_KEY, id);
+          localStorage.removeItem(STORAGE_KEY);
+        } catch {}
+      }
+      const activeId = localStorage.getItem(STORAGE_ACTIVE_KEY);
+      if (!activeId) return false;
+      const saved = localStorage.getItem(STORAGE_KEY + ':' + activeId);
       if (!saved) return false;
       const s = JSON.parse(saved);
       if (s.title || (s.sections && s.sections.length > 0)) {
@@ -8818,8 +8842,12 @@
       state.leftDrawerMode = 'structure';
       state.leftDrawerOpen = true;
       state.leftDrawerScrollTopByMode = { structure: 0 };
+      const clearKey = getDocStorageKey();
       state.sections = []; state.previewTab = 'visual'; state.boardDimensionId = '';
-      try { localStorage.removeItem(STORAGE_KEY); } catch {}
+      try {
+        localStorage.removeItem(clearKey);
+        localStorage.removeItem(STORAGE_ACTIVE_KEY);
+      } catch {}
       renderTopBar(); renderLeft(); renderRight();
     });
     document.getElementById('top-load')?.addEventListener('click', () => {
@@ -12475,8 +12503,17 @@ open docs/living-doc-compositor.html</pre>
     await discoverLibrary();
     state.leftDrawerOpen = !isEmbedded;
     state.leftDrawerMode = 'structure';
-    // When embedded in a living doc iframe, skip auto-load — parent will call loadDocumentData
-    const restored = isEmbedded ? false : autoLoad();
+    // Embedded mode: block autoLoad, autoSave, and referrer hydration; wait
+    // for the parent's postMessage-driven applyDocumentData so the doc on
+    // disk is the only source of truth for fingerprint checks. See #58.
+    if (isEmbedded) {
+      state.pendingDocLoad = true;
+      renderTopBar();
+      renderLeft();
+      renderRight();
+      return;
+    }
+    const restored = autoLoad();
     if (restored && state.sections.length > 0) state.previewTab = 'visual';
     // Detect if we arrived from a living doc via the pencil link
     const ref = document.referrer;
@@ -12498,6 +12535,7 @@ open docs/living-doc-compositor.html</pre>
   // Allow parent page to load document data (when embedded as iframe in a living doc)
   // Supports both direct function call and postMessage
   function applyDocumentData(json) {
+    state.pendingDocLoad = false;
     state.leftDrawerMode = 'structure';
     state.leftDrawerOpen = !isEmbedded;
     state.title = json.title || '';


### PR DESCRIPTION
## Summary

Two coordinated changes so a freshly crystallized living doc opened via the pencil icon no longer reads as stale in the Flow view.

1. **Per-doc localStorage keying.** State is now keyed by \`docId\` or \`canonicalOrigin\` (fallback: \`_default\`). A separate \`…:active\` pointer tracks which slot to restore on standalone boot. Legacy single-key state migrates into its resolved per-doc slot on first boot.
2. **Guarantee postMessage wins in embedded mode.** Embedded iframes now set \`pendingDocLoad = true\` at init and block \`autoSave\`, skip \`autoLoad\`, and skip the referrer-based hydration path. \`applyDocumentData\` clears the flag when the parent's \`load-document\` message arrives — the doc on disk becomes the only source of truth for the fingerprint check.

Closes #58.

## Test plan

- [ ] In a browser that already has compositor state from an earlier session (e.g. edited doc A on \`localhost:8111\`), open a freshly crystallized doc B via pencil → Flow tab should open with no stale banner and wires at full color.
- [ ] Open doc A, edit something, switch to doc B, edit something, switch back to doc A. Each doc's state persists independently under its own slot — no bleed.
- [ ] \"New\" from the top menu clears the active doc's slot and the active pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)