### PR TITLE
Body canvas: star-from-selection wires, drop resting chain

### DIFF
--- a/docs/living-doc-compositor.html
+++ b/docs/living-doc-compositor.html
@@ -10474,11 +10474,24 @@
     const canvas = document.getElementById('l2-body-canvas');
     const svg = document.getElementById('l2-body-wires');
     if (!canvas || !svg) return;
-    const sections = Array.isArray(json.sections) ? json.sections : [];
 
     const canvasRect = canvas.getBoundingClientRect();
     svg.setAttribute('width',  String(canvasRect.width));
     svg.setAttribute('height', String(canvasRect.height));
+
+    // No selection → no wires. Cross-card ticket sharing is a set, not a
+    // sequence, so we refuse to imply an order at rest. See #73.
+    const selectedKey = state.l2SelectedCard || null;
+    if (!selectedKey) {
+      svg.innerHTML = '';
+      return;
+    }
+
+    const sections = Array.isArray(json.sections) ? json.sections : [];
+    const [selSid, selCid] = selectedKey.split('::');
+    const selSection = sections.find((s) => s.id === selSid);
+    const selCard = selSection?.data?.find((c) => c?.id === selCid);
+    if (!selCard) { svg.innerHTML = ''; return; }
 
     const cssEscape = (s) => String(s).replace(/[^a-zA-Z0-9_-]/g, (ch) => `\\${ch}`);
     const bezier = (x1, y1, x2, y2) => {
@@ -10486,49 +10499,38 @@
       return `M ${x1} ${y1} C ${mid} ${y1}, ${mid} ${y2}, ${x2} ${y2}`;
     };
 
-    // Group cards by ticket; skip cards inside collapsed frames.
-    const cardsByTicket = new Map();
-    sections.forEach((s) => {
-      const frame = canvas.querySelector(`[data-section-id="${cssEscape(s.id)}"]`);
-      if (!frame || frame.classList.contains('l2-frame-collapsed')) return;
-      const cards = Array.isArray(s.data) ? s.data : [];
-      cards.forEach((c) => {
-        const cid = c?.id;
-        if (!cid) return;
-        (Array.isArray(c.ticketIds) ? c.ticketIds : []).forEach((raw) => {
-          const tid = flowTicketNumber(raw);
-          if (!tid) return;
-          if (!cardsByTicket.has(tid)) cardsByTicket.set(tid, []);
-          cardsByTicket.get(tid).push({ s: s.id, c: cid });
+    const selTickets = (Array.isArray(selCard.ticketIds) ? selCard.ticketIds : [])
+      .map(flowTicketNumber).filter(Boolean);
+    if (selTickets.length === 0) { svg.innerHTML = ''; return; }
+
+    const selEl = canvas.querySelector(
+      `[data-section-id="${cssEscape(selSid)}"] [data-card-id="${cssEscape(selCid)}"]`
+    );
+    if (!selEl) { svg.innerHTML = ''; return; }
+    const selRect = selEl.getBoundingClientRect();
+    const sx = selRect.left + selRect.width / 2 - canvasRect.left;
+    const sy = selRect.top  + selRect.height / 2 - canvasRect.top;
+
+    const paths = [];
+    selTickets.forEach((tid) => {
+      const color = flowColorForTicket(tid);
+      sections.forEach((s) => {
+        const frame = canvas.querySelector(`[data-section-id="${cssEscape(s.id)}"]`);
+        if (!frame || frame.classList.contains('l2-frame-collapsed')) return;
+        (Array.isArray(s.data) ? s.data : []).forEach((c) => {
+          if (!c?.id) return;
+          if (s.id === selSid && c.id === selCid) return;
+          const tids = (Array.isArray(c.ticketIds) ? c.ticketIds : []).map(flowTicketNumber);
+          if (!tids.includes(tid)) return;
+          const el = frame.querySelector(`[data-card-id="${cssEscape(c.id)}"]`);
+          if (!el) return;
+          const r = el.getBoundingClientRect();
+          const x2 = r.left + r.width / 2 - canvasRect.left;
+          const y2 = r.top  + r.height / 2 - canvasRect.top;
+          paths.push(`<path class="l2-body-wire l2-body-wire-highlight" stroke="${color}" d="${bezier(sx, sy, x2, y2)}"/>`);
         });
       });
     });
-
-    const selectedKey = state.l2SelectedCard || null;
-    const paths = [];
-    for (const [tid, cards] of cardsByTicket.entries()) {
-      if (cards.length < 2) continue;
-      const color = flowColorForTicket(tid);
-      for (let i = 0; i < cards.length - 1; i++) {
-        const a = cards[i], b = cards[i + 1];
-        const aEl = canvas.querySelector(`[data-section-id="${cssEscape(a.s)}"] [data-card-id="${cssEscape(a.c)}"]`);
-        const bEl = canvas.querySelector(`[data-section-id="${cssEscape(b.s)}"] [data-card-id="${cssEscape(b.c)}"]`);
-        if (!aEl || !bEl) continue;
-        const ar = aEl.getBoundingClientRect();
-        const br = bEl.getBoundingClientRect();
-        const x1 = ar.left + ar.width / 2 - canvasRect.left;
-        const y1 = ar.top  + ar.height / 2 - canvasRect.top;
-        const x2 = br.left + br.width / 2 - canvasRect.left;
-        const y2 = br.top  + br.height / 2 - canvasRect.top;
-        const aKey = `${a.s}::${a.c}`;
-        const bKey = `${b.s}::${b.c}`;
-        const touchesSelection = selectedKey === aKey || selectedKey === bKey;
-        const cls = selectedKey
-          ? `l2-body-wire ${touchesSelection ? 'l2-body-wire-highlight' : 'l2-body-wire-dim'}`
-          : 'l2-body-wire';
-        paths.push(`<path class="${cls}" stroke="${color}" d="${bezier(x1, y1, x2, y2)}"/>`);
-      }
-    }
     svg.innerHTML = paths.join('');
   }
 


### PR DESCRIPTION
## Summary

Drops the document-order chain wire rule. Cross-card ticket sharing is a set, not a sequence, so the compositor no longer implies an ordering at rest.

## Behavior

- **No selection:** body canvas renders frames and cards only. No cross-card wires.
- **On selection:** wires fan out from the selected card to every other card that shares at least one ticket with it. One wire per shared ticket, colored per ticket hash. Cards in collapsed frames are excluded.
- **Deselect:** wires clear.

Column order no longer affects which wires appear — reordering is pure layout.

## Why

Reported while exploring the Level 2 canvas: some cards lit up on selection but had no wire to the selected card, because the chain rule wired consecutive pairs in document order and skipped transitive co-ticket cards. The fix moves from \"chain through document order\" to \"set membership of a shared ticket.\"

Closes #73. Follow-up to #65.

## Test plan

- [ ] Open a doc with several cards sharing tickets. Body mode shows no wires by default.
- [ ] Click a card with N co-ticket siblings → exactly N wires fan out from it.
- [ ] Click a card with no co-ticket siblings → no wires.
- [ ] Reorder columns; same selection produces the same set of wires.
- [ ] Deselect by clicking the background → wires clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)