### PR TITLE
Add pre-push hook guarding the embedded compositor sync

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Pre-push guard: ensures docs/living-doc-compositor.html embeds the current
+# registry, i18n, and template content. Without this check, commits that change
+# scripts/living-doc-registry.json, scripts/living-doc-i18n.json, or the
+# embedded template JSONs can reach origin without running
+# sync-compositor-embeds.mjs, which breaks the i18n contract test on main.
+#
+# Install once with: npm run install-hooks
+set -e
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if ! node scripts/sync-compositor-embeds.mjs --check >/dev/null 2>&1; then
+  echo ""
+  echo "✗ Embedded compositor is out of sync."
+  echo "  Run: node scripts/sync-compositor-embeds.mjs"
+  echo "  Then stage docs/living-doc-compositor.html, amend or commit, and push again."
+  echo ""
+  exit 1
+fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,9 @@ Add a new locale key to `scripts/living-doc-i18n.json` with all the same keys as
 ### When asked to modify the compositor GUI
 Edit `docs/living-doc-compositor.html`. This is a single self-contained HTML file. The same file is embedded in every rendered living doc via srcdoc iframe. Changes here propagate to all newly rendered docs.
 
+### After changing the registry, i18n, or embedded templates
+Run `node scripts/sync-compositor-embeds.mjs` before committing. The registry, i18n strings, and template JSONs are embedded inline into `docs/living-doc-compositor.html`; if that embed drifts from the source files, the `i18n` contract test fails on CI. A `pre-push` git hook runs `--check` to catch this locally (install once with `npm install` or `npm run install-hooks`).
+
 ### When asked to create a living doc for a domain
 1. Create a JSON file following the universal format (see `docs/living-doc-empty.json` for the skeleton)
 2. Add `sections` with `convergenceType` references to types in the registry

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "test": "npm run test:contract && npm run test:e2e",
     "test:contract": "node tests/contract/i18n.spec.mjs && node tests/contract/registry.spec.mjs && node tests/contract/render.spec.mjs",
     "test:e2e": "playwright test tests/e2e",
-    "test:deploy": "BASE_URL=https://triadflow.github.io/living-doc-compositor/ playwright test tests/e2e/deploy-smoke.spec.mjs"
+    "test:deploy": "BASE_URL=https://triadflow.github.io/living-doc-compositor/ playwright test tests/e2e/deploy-smoke.spec.mjs",
+    "install-hooks": "git config core.hooksPath .githooks",
+    "postinstall": "npm run install-hooks"
   },
   "devDependencies": {
     "@playwright/test": "^1.57.0"


### PR DESCRIPTION
## Summary

Shifts the \`sync-compositor-embeds\` check left. Two recent commits to main broke the i18n contract test because changes to \`scripts/living-doc-registry.json\`, \`scripts/living-doc-i18n.json\`, or embedded templates were pushed without re-running the embed script. A \`.githooks/pre-push\` script now catches the drift locally.

## Changes

- \`.githooks/pre-push\` — runs \`node scripts/sync-compositor-embeds.mjs --check\` and blocks push with the fix command if the embed has drifted.
- \`package.json\` — adds \`install-hooks\` and a \`postinstall\` that wires \`git config core.hooksPath .githooks\` so anyone running \`npm install\` picks up the hook automatically.
- \`AGENTS.md\` — calls out the sync step as part of any registry/i18n/template change.

No new runtime dependencies. No new CI behavior — the existing contract test remains the last line of defense.

Closes #79.

## Test plan

- [ ] Fresh clone → \`npm install\` → \`git config --get core.hooksPath\` returns \`.githooks\`.
- [ ] Modify \`scripts/living-doc-registry.json\` without running sync, try to push → hook blocks with a clear error message.
- [ ] Run the sync, commit the updated \`docs/living-doc-compositor.html\`, push → hook passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)