### PR TITLE
[codex] Add MCP doorway blog article

### DIFF
--- a/docs/blog-a-to-z-run-skill-field-note.html
+++ b/docs/blog-a-to-z-run-skill-field-note.html
@@ -300,11 +300,11 @@
         <h3>Two ways of making complexity legible to AI</h3>
       </div>
     </a>
-    <a href="blog.html" class="pn-card next disabled">
+    <a href="blog-mcp-server-living-doc-workbench.html" class="pn-card next">
       <span class="dir">Next &rarr;</span>
       <div>
-        <div class="cat" style="color:var(--muted)">&nbsp;</div>
-        <h3 style="color:var(--muted)">You're at the last piece in this issue.</h3>
+        <div class="cat">Essay · Substrate</div>
+        <h3>A living doc works better with a door</h3>
       </div>
     </a>
   </div>

--- a/docs/blog-mcp-server-living-doc-workbench.html
+++ b/docs/blog-mcp-server-living-doc-workbench.html
@@ -1,0 +1,388 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>A living doc works better with a door &middot; Living Doc Compositor</title>
+<meta name="description" content="Living docs already give humans and agents one typed working surface. A local MCP doorway lets agents operate that surface through shared document operations while the artifact remains portable." />
+<link rel="stylesheet" href="styles.css" />
+<style>
+  .door-diagram{
+    display:grid;
+    grid-template-columns:1fr auto 1fr;
+    gap:18px;
+    align-items:stretch;
+    margin:2.2em -34px;
+  }
+  .door-panel{
+    border:1px solid var(--line);
+    border-radius:8px;
+    background:#fff;
+    padding:20px;
+  }
+  .door-panel h3{
+    margin:0 0 10px;
+    font-size:18px;
+  }
+  .door-panel p{
+    margin:.55em 0 0;
+    color:var(--muted);
+    font-size:14px;
+    line-height:1.58;
+  }
+  .door-arrow{
+    display:flex;
+    align-items:center;
+    justify-content:center;
+    color:var(--accent);
+    font-family:var(--font-mono);
+    font-size:12px;
+    font-weight:700;
+    letter-spacing:.08em;
+    text-transform:uppercase;
+    writing-mode:vertical-rl;
+    text-orientation:mixed;
+  }
+  .client-grid{
+    display:grid;
+    grid-template-columns:repeat(4,minmax(0,1fr));
+    gap:12px;
+    margin:1.8em -20px;
+  }
+  .client-card{
+    border:1px solid var(--line);
+    border-radius:8px;
+    background:color-mix(in srgb,var(--accent) 5%,white);
+    padding:15px;
+  }
+  .client-card strong{
+    display:block;
+    margin-bottom:6px;
+    font-size:14px;
+  }
+  .client-card span{
+    display:block;
+    color:var(--muted);
+    font-size:13px;
+    line-height:1.48;
+  }
+  .principle-list{
+    display:grid;
+    grid-template-columns:repeat(2,minmax(0,1fr));
+    gap:12px;
+    margin:1.8em 0;
+  }
+  .principle{
+    border-left:3px solid var(--accent);
+    border-radius:0 8px 8px 0;
+    background:color-mix(in srgb,var(--accent) 7%,white);
+    padding:14px 16px;
+  }
+  .principle strong{
+    display:block;
+    margin-bottom:4px;
+  }
+  .principle span{
+    color:var(--muted);
+    font-size:13.5px;
+    line-height:1.52;
+  }
+  .small-note{
+    color:var(--muted);
+    font-size:13px;
+    line-height:1.55;
+  }
+  @media (max-width:900px){
+    .door-diagram,.client-grid,.principle-list{grid-template-columns:1fr;margin-left:0;margin-right:0}
+    .door-arrow{writing-mode:horizontal-tb;padding:4px 0}
+  }
+</style>
+</head>
+<body>
+
+<div class="read-progress"><div class="bar" id="readBar"></div></div>
+
+<header class="top-bar">
+  <a href="index.html" class="brand">
+    <span class="logo">L</span>
+    <span class="brand-name">Living Doc Compositor</span>
+  </a>
+  <span class="spacer"></span>
+  <nav>
+    <a href="living-doc-compositor.html">Compositor</a>
+    <a href="index.html">Docs</a>
+    <a href="blog.html" class="active">Writing</a>
+  </nav>
+  <a href="https://github.com/triadflow/living-doc-compositor" class="github">
+    <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+    Repo
+  </a>
+</header>
+
+<section class="post-header">
+  <div class="stage">
+    <div class="breadcrumbs">
+      <a href="index.html">Home</a>
+      <span class="sep">/</span>
+      <a href="blog.html">Writing</a>
+      <span class="sep">/</span>
+      <span class="current">A living doc works better with a door</span>
+    </div>
+
+    <div class="kicker">
+      <span class="eyebrow">Essay &middot; Substrate</span>
+      <span class="eyebrow muted">Issue 01 &middot; &#8470; 08</span>
+    </div>
+
+    <h1>A living doc works better with a door.</h1>
+
+    <p class="dek">
+      Living docs already give humans and agents one typed working surface. The next step is letting agents enter that surface at the right depth &mdash; quick overview, deep structure, diagnostics, then valid operations &mdash; while the artifact remains portable. In this implementation, the doorway is a small local MCP server.
+    </p>
+
+    <div class="byline-row">
+      <div class="author">
+        <span class="avatar">RL</span>
+        <div class="who">
+          <span class="name">Rene Luijk</span>
+          <span class="affil">Triadflow</span>
+        </div>
+      </div>
+      <div class="meta">
+        <span><span class="label">Prepared</span><span class="v">Apr 28, 2026</span></span>
+        <span class="pipe"></span>
+        <span><span class="label">Read</span><span class="v">8 min</span></span>
+        <span class="pipe"></span>
+        <span><span class="label">File</span><span class="v" style="font-family:var(--font-mono)">docs/blog-mcp-server-living-doc-workbench.html</span></span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<article>
+  <div class="article">
+    <div class="prose">
+
+      <p class="lede">A living doc turns prior work into loadable state. You open a hard issue, a research thread, a feature build, or a long-running monitor, and the shape of the work is already there: objective, sections, evidence, decisions, and current status. A fresh human or agent session starts from the same typed surface instead of reconstructing the project from scattered sources.</p>
+
+      <p>That artifact is readable by people, structured enough for agents, and portable enough to outlive the tool that rendered it. It is not a transcript or a dashboard. It is the working surface where the team can see what the work is, what has moved, and what still needs judgment.</p>
+
+      <p>Once that surface is active, it becomes part of the work loop. A source gets integrated. A card changes status. Evidence attaches to a section. A facet becomes covered. A patch is validated. The HTML is rendered again. The document is no longer just something an agent reads before working; it is one of the places where the work is advanced.</p>
+
+      <p>The local MCP server is a doorway in that working artifact: a governed way for tools to enter the document at the right depth, perform repeated operations, and leave the document still owning its own state.</p>
+
+      <div class="callout callout-positive">
+        <span class="lbl">Operational surface</span>
+        <p>A living doc becomes more useful when agents can enter and operate it through the same contracts the compositor and renderer already respect. The doorway gives repeated moves a shared route: get oriented, explain the type, validate the patch, attach the source, map the coverage, render the artifact.</p>
+      </div>
+
+      <h2>Entering At The Right Depth</h2>
+
+      <p>There are several ways for an agent to enter a living doc. The rendered HTML is the broadest entry point: good for human reading, good for seeing the whole page, and good for preserving the artifact as something portable. The raw JSON is more exact: sections, card ids, convergence types, objective facets, coverage edges, invariants, refs, timestamps, and source metadata are all visible without scraping the rendered page.</p>
+
+      <p>The MCP surface adds a third entry point. It can give the model a structured orientation before the model decides what to do next. Not just "load this document", but "tell me the registry vocabulary", "reflect on this structure", "find uncovered facets", "evaluate governance", "list applicable invariants", or "validate this patch against the current doc". The current server already has tools in that direction. A fuller version should also expose direct document retrieval and overview calls: quick summary, deep JSON overview, section/card lookup, source refs, and readiness state.</p>
+
+      <p>That matters at inference time. Many agent failures start before implementation: the model enters the work at the wrong level of detail. Too little context and it invents the frame. Too much undifferentiated context and it spends its first pass sorting the artifact instead of acting on it. A living doc gives the bounded artifact; the doorway lets the agent choose the depth of entry.</p>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Entry point</th>
+            <th>What it is good for</th>
+            <th>Where it struggles</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Rendered HTML</td>
+            <td>Human reading, full page context, portable handoff.</td>
+            <td>Exact structure can be harder for an agent to manipulate without parsing.</td>
+          </tr>
+          <tr>
+            <td>Raw JSON</td>
+            <td>Exact fields, ids, sections, governance data, source references.</td>
+            <td>Often too blunt as an inference-time entry point; the model still has to decide what slice matters.</td>
+          </tr>
+          <tr>
+            <td>MCP calls</td>
+            <td>Targeted orientation, diagnostics, validation, retrieval, and mutation.</td>
+            <td>Only as useful as the operations exposed; the artifact must remain the source of truth.</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>Why The Run Skill Found It First</h2>
+
+      <p>The A-to-Z run skill was the first place where this became unavoidable. That skill asks Codex to work through a governed living doc while still delivering source-system outcomes: code changes, issue updates, verification, PR state. It needs the doc to be more than context. It needs the doc to behave like a working surface.</p>
+
+      <p>Codex can do the work without MCP. The skill already gives it the living-doc semantics. MCP improves the orientation and mechanical layers: registry lookup, structure reflection, coverage checks, governance evaluation, source linking, patch validation, patch application, and rendering. Those are all things the model can steer from prose, but they are sharper as direct operations. The expected gain is focus: less model effort spent turning document rules into file edits, more effort left for understanding the source system, making the change, verifying it, and reporting what is still unresolved.</p>
+
+      <p>During a run, the agent has to select an initial structure, scaffold a run doc, add source cards, map coverage to objective facets, check governance, validate proposed patches, render the artifact, and keep the distinction between "the document is coherent" and "the objective is actually done." Those are not prose tasks. They are state transitions.</p>
+
+      <p>The skill exposed the pressure first because it was the most demanding client. The server is still not a feature of that skill. It is a reusable doorway for any living-doc client that starts doing repeated operations.</p>
+
+      <div class="door-diagram">
+        <section class="door-panel">
+          <h3>Prompt-only operation</h3>
+          <p>The skill can already explain the registry, patch shape, governance rules, and render path well enough for a capable agent to operate.</p>
+          <p>The cost is that each run spends model attention translating those instructions into mechanical document actions.</p>
+        </section>
+        <div class="door-arrow">shared contract</div>
+        <section class="door-panel">
+          <h3>MCP-assisted operation</h3>
+          <p>The repeated operations become direct calls: retrieve, explain, reflect, link, validate, evaluate, render.</p>
+          <p>The agent still makes the judgment calls, but spends less effort on operating the document machinery.</p>
+        </section>
+      </div>
+
+      <h2>The Document Still Owns The Truth</h2>
+
+      <p>A door is not a new house. The server does not become the source of truth. The JSON and standalone HTML remain the durable artifact. You can still email the file, open it offline, drop it in a repo, or load it into a different agent. The door is local and optional. It exists so active tools can operate on the artifact while the artifact is being worked on.</p>
+
+      <p>Living docs and graphs remain different surfaces. The artifact is the bounded working context; the graph is a navigation layer across artifacts. The MCP server sits close to the artifact. It is not an index of all work. It is the operating handle for one document at a time.</p>
+
+      <p>The registry is the shared semantic vocabulary. A skill can teach that language in prose. The server makes part of the language operational: a client can ask the local environment what a convergence type means, validate a patch against the same registry the compositor and renderer use, and avoid spending inference on the mechanical parts of the language.</p>
+
+      <p>Capable agents do not remove the need for shared commitments. They increase it. The server is a practical optimization around that pressure: when agents act repeatedly, some commitments are better expressed as callable checks than repeated prose instructions.</p>
+
+      <h2>What The Door Lets In</h2>
+
+      <p>The current run skill is just the first visible client. Other clients can use the same doorway when repeated document operations start to matter.</p>
+
+      <div class="client-grid">
+        <div class="client-card"><strong>Run skills</strong><span>Use the doc as governed state while real work happens in GitHub, the repo, or another source system.</span></div>
+        <div class="client-card"><strong>Sync skills</strong><span>Refresh trackers, dossiers, and monitoring docs with less repeated registry and render handling.</span></div>
+        <div class="client-card"><strong>Compositor actions</strong><span>Let a browser action ask the local environment to validate or propose changes while the file remains portable.</span></div>
+        <div class="client-card"><strong>Future agents</strong><span>Let different engines enter through the same contract instead of baking the rules into one model's prompt.</span></div>
+      </div>
+
+      <p>The living-doc project is not betting on one agent, one IDE, one model, or one chat surface. It is betting on a typed artifact that can survive many of them. MCP fits because it is a neutral doorway. It lets the document expose what can be done to it without deciding which agent gets to do the work.</p>
+
+      <p>Repeated clients get a lower-friction way to operate on the same artifact. They can still work without it. They just spend more of the run translating prose instructions into document operations, and less of the run on the source-system task the document exists to support.</p>
+
+      <h2>The Boundary Is The Design</h2>
+
+      <p>Skills make judgment calls. The server owns repeatable transitions.</p>
+
+      <p>A skill can decide that a source is worth integrating, that a section needs a new card, that a trap deserves an invariant, or that the objective is not ready even if the document is coherent. Those are interpretive moves. They require context, taste, and responsibility.</p>
+
+      <p>The server should answer narrower questions: given this document and this proposed change, is the patch valid? Given this objective, what starter structure follows from the registry? Given this card status, does the evidence satisfy the governance rules? Given this JSON file, can it render? Those questions deserve one implementation, not twenty prompt paragraphs.</p>
+
+      <div class="principle-list">
+        <div class="principle"><strong>Keep judgment near the agent.</strong><span>Sequencing, salience, and final responsibility belong in the skill or human workflow.</span></div>
+        <div class="principle"><strong>Keep contracts near the document.</strong><span>Registry interpretation, validation, coverage, governance, and render rules should be shared.</span></div>
+        <div class="principle"><strong>Keep the artifact portable.</strong><span>The server helps active work. The file still travels without it.</span></div>
+        <div class="principle"><strong>Promote slowly.</strong><span>An operation belongs in the server only when it repeats and has a stable contract.</span></div>
+      </div>
+
+      <p>The server should stay boring. If an operation is still exploratory, leave it in the skill. If it repeats across skills, if it has clear inputs and outputs, if getting it wrong would fragment the meaning of the doc, move it behind the door.</p>
+
+      <h2>Live Artifacts Need Live Operations</h2>
+
+      <p>Living docs are small, named, portable semantic artifacts for complex work. Humans and agents can keep them current together. The artifact is readable, typed, and durable enough to preserve agreement over time. While the work is alive, the artifact also needs efficient ways to accept valid changes.</p>
+
+      <p>The MCP server makes that live-editing loop cheaper and more consistent. A capable agent can already interpret the doc; the doorway lets the doc offer direct operations instead of asking the agent to infer every operation from prose. The doc can expose its vocabulary, valid edits, governance checks, and render path through calls that leave the artifact intact.</p>
+
+      <p>A living doc should not only be read by agents. It should be worked on by agents under the same contracts humans see in the compositor.</p>
+
+      <aside class="pullquote">
+        <p>The file is the memory. The registry is the language. The MCP server is the door.</p>
+        <cite>&mdash; Three surfaces of the same substrate</cite>
+      </aside>
+
+      <h2>What Comes Next</h2>
+
+      <p>The current server is early. It can inspect registry types, scaffold and refine structure, attach sources, map coverage, evaluate governance, validate patches, apply patches, and render. Those operations are enough to support the run skill and make the artifact easier to keep current during active work.</p>
+
+      <p>The next step is not more cleverness. It is restraint and reuse. Promote only the operations that multiple clients need. Let monitoring syncs, source-integration flows, compositor actions, and future standing processes discover the same door rather than each building a private one.</p>
+
+      <p>When this works, the server mostly disappears from the user's mind. You open a living doc. You ask an agent to work. The agent enters the doc, respects its language, updates it through valid moves, and leaves behind a portable artifact another mind can trust.</p>
+
+      <h2>Source Notes</h2>
+
+      <ul>
+        <li>MCP server: <code>scripts/living-doc-mcp-server.mjs</code>.</li>
+        <li>Run command: <code>npm run ldoc:mcp</code>.</li>
+        <li>Contract test: <code>tests/contract/mcp-server.spec.mjs</code>.</li>
+        <li>Boundary reference: <code>.agents/skills/inference-living-doc-run-codex/references/cli-mcp-boundary.md</code>.</li>
+        <li>Related field note: <a href="blog-a-to-z-run-skill-field-note.html">The run skill is starting to behave like a small delivery system</a>.</li>
+      </ul>
+
+      <div class="article-tags">
+        <div class="tags">
+          <a href="#" class="tag">Essay</a>
+          <a href="#" class="tag">MCP</a>
+          <a href="#" class="tag">Substrate</a>
+          <a href="#" class="tag">Agent coordination</a>
+        </div>
+        <span class="sp"></span>
+        <span class="small-note">Static artifact: <code>docs/blog-mcp-server-living-doc-workbench.html</code></span>
+      </div>
+
+    </div>
+
+    <div class="author-card">
+      <div class="inner">
+        <span class="avatar">RL</span>
+        <div>
+          <div class="name">Rene Luijk</div>
+          <div class="bio">
+            Builds Triadflow and Living Doc Compositor. The goal is a thin semantic layer that humans and agents can both use as working state.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</article>
+
+<nav class="pn-nav">
+  <div class="pn-label">
+    <span class="tag">More in Writing</span>
+    <span class="line"></span>
+  </div>
+  <div class="pn-grid">
+    <a href="blog-a-to-z-run-skill-field-note.html" class="pn-card">
+      <span class="dir">&larr; Previous</span>
+      <div>
+        <div class="cat">Field note</div>
+        <h3>The run skill is starting to behave like a small delivery system</h3>
+      </div>
+    </a>
+    <a href="blog.html" class="pn-card next disabled">
+      <span class="dir">Next &rarr;</span>
+      <div>
+        <div class="cat" style="color:var(--muted)">&nbsp;</div>
+        <h3 style="color:var(--muted)">You're at the last piece in this issue.</h3>
+      </div>
+    </a>
+  </div>
+</nav>
+
+<footer class="site-footer">
+  <div class="stage">
+    <div class="foot-inner">
+      <div>Living Doc Compositor &middot; MIT &middot; Rene Luijk / Triadflow</div>
+      <div class="links">
+        <a href="index.html">Home</a>
+        <a href="blog.html">Writing</a>
+        <a href="https://github.com/triadflow/living-doc-compositor">Repo</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<script>
+  const bar = document.getElementById('readBar');
+  const update = () => {
+    const h = document.documentElement;
+    const scrolled = h.scrollTop;
+    const total = h.scrollHeight - h.clientHeight;
+    const pct = total > 0 ? (scrolled / total) * 100 : 0;
+    bar.style.width = pct + '%';
+  };
+  window.addEventListener('scroll', update, {passive:true});
+  update();
+</script>
+
+</body>
+</html>

--- a/docs/blog.html
+++ b/docs/blog.html
@@ -269,7 +269,7 @@
   <div class="stage">
     <div class="more-posts-head">
       <h2>Series 01 &middot; The Living Docs Journal</h2>
-      <span class="count">07 pieces</span>
+      <span class="count">08 pieces</span>
       <span class="line"></span>
     </div>
 
@@ -418,6 +418,28 @@
             </div>
             <div class="side">
               <span class="date">Apr 27, 2026</span>
+              <span>8 min read</span>
+              <span>Rene Luijk</span>
+              <span style="margin-top:6px">Read <span class="arr">→</span></span>
+            </div>
+          </div>
+        </a>
+      </li>
+      <li>
+        <a href="blog-mcp-server-living-doc-workbench.html" style="display:block;color:inherit">
+          <div class="post-row">
+            <div class="num">№ 08</div>
+            <div class="body">
+              <div class="cat">Essay · Substrate</div>
+              <div class="post-title">A living doc works better with a door</div>
+              <div class="post-dek">
+                Living docs already give humans and agents one typed working surface. The next step is
+                letting agents enter that surface at the right depth &mdash; quick overview, deep structure,
+                diagnostics, then valid operations &mdash; while the artifact remains portable.
+              </div>
+            </div>
+            <div class="side">
+              <span class="date">Apr 28, 2026</span>
               <span>8 min read</span>
               <span>Rene Luijk</span>
               <span style="margin-top:6px">Read <span class="arr">→</span></span>


### PR DESCRIPTION
## What changed

- Added Series 01 article `A living doc works better with a door`.
- Updated the Series 01 index from 7 to 8 pieces.
- Updated the previous article's next link to point to the new post.

## Why

The article frames the living-doc MCP server as an inference-time doorway into a living doc: quick overview, deeper structure, diagnostics, and valid operations while the portable artifact remains the source of truth.

## Validation

- `node tests/contract/mcp-server.spec.mjs`
